### PR TITLE
SecDependancy

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -30,14 +30,14 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -51,4 +51,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -66,7 +66,7 @@ jobs:
 
         - 
             name: Log in to the Container registry
-            uses: docker/login-action@v1
+            uses: docker/login-action@v2
             with:
                 registry: ghcr.io
                 username: ${{ github.actor }}
@@ -75,13 +75,13 @@ jobs:
         - 
             name: Extract metadata (tags, labels) for Docker
             id: meta
-            uses: docker/metadata-action@v3
+            uses: docker/metadata-action@v4
             with:
                 images: ghcr.io/slucky31/mycomicsmanager-web/mycomicsmanager-web
 
         - 
             name: Build and push Docker image MyComicsManagerWeb
-            uses: docker/build-push-action@v2
+            uses: docker/build-push-action@v4
             with:
                 context: .
                 file: ./MyComicsManagerWeb/Dockerfile
@@ -119,7 +119,7 @@ jobs:
 
         - 
             name: Build and push Docker image MyComicsManagerApi
-            uses: docker/build-push-action@v2
+            uses: docker/build-push-action@v4
             with:
                 context: .
                 file: ./MyComicsManagerApi/Dockerfile

--- a/MyComicsManagerApi.Tests/MyComicsManagerApiTests.csproj
+++ b/MyComicsManagerApi.Tests/MyComicsManagerApiTests.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/MyComicsManagerApi/MyComicsManagerApi.csproj
+++ b/MyComicsManagerApi/MyComicsManagerApi.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.16" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision" Version="7.0.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.19.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="PdfPig" Version="0.1.8" />

--- a/MyComicsManagerApi/MyComicsManagerApi.csproj
+++ b/MyComicsManagerApi/MyComicsManagerApi.csproj
@@ -19,12 +19,12 @@
     <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="PdfPig" Version="0.1.7" />
+    <PackageReference Include="PdfPig" Version="0.1.8" />
     <PackageReference Include="sharpcompress" Version="0.32.2" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
-    <PackageReference Include="Hangfire.Core" Version="1.7.32" />
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.32" />
-    <PackageReference Include="Hangfire.Mongo" Version="1.9.1" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.3" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.3" />
+    <PackageReference Include="Hangfire.Mongo" Version="1.9.6" />
     <PackageReference Include="Hangfire.Console" Version="1.4.2" />
     <PackageReference Include="CloudinaryDotNet" Version="1.20.0" />
   </ItemGroup>


### PR DESCRIPTION
Bump Hangfire.Core from 1.7.32 to 1.8.3
Bump Hangfire.Mongo from 1.9.1 to 1.9.6
Bump PdfPig from 0.1.7 to 0.1.8
Bump coverlet.collector from 3.1.2 to 6.0.0
Bump docker/metadata-action from 3 to 4
Bump docker/login-action from 1 to 
Bump github/codeql-action from 1 to 2
Bump actions/checkout from 2 to 3
Bump docker/build-push-action from 2 to 4