### PR TITLE
fix : upgrade dependancies

### DIFF
--- a/.versionize
+++ b/.versionize
@@ -1,5 +1,5 @@
 {
-  "changelogAll": false,
+  "changelogAll": true,
   "changelog": {
     "header": "My Comics Manager Changelog",
     "sections": [

--- a/MyComicsManager.Model.Shared/MyComicsManager.Model.Shared.csproj
+++ b/MyComicsManager.Model.Shared/MyComicsManager.Model.Shared.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
+        <PackageReference Include="MongoDB.Driver" Version="2.20.0" />
     </ItemGroup>
     
 </Project>

--- a/MyComicsManagerApi/MyComicsManagerApi.csproj
+++ b/MyComicsManagerApi/MyComicsManagerApi.csproj
@@ -17,11 +17,11 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.16" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision" Version="7.0.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.19.2" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.20.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="PdfPig" Version="0.1.8" />
-    <PackageReference Include="sharpcompress" Version="0.32.2" />
+    <PackageReference Include="sharpcompress" Version="0.33.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
     <PackageReference Include="Hangfire.Core" Version="1.8.3" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.3" />

--- a/MyComicsManagerWeb/MyComicsManagerWeb.csproj
+++ b/MyComicsManagerWeb/MyComicsManagerWeb.csproj
@@ -8,8 +8,8 @@
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.Identity.MongoDbCore" Version="3.1.2" />
 		<PackageReference Include="GitInfo" Version="2.3.0" />
-		<PackageReference Include="MudBlazor" Version="6.4.1" />
-		<PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+		<PackageReference Include="MudBlazor" Version="6.6.0" />
+		<PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
 		<PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="7.0.0" />


### PR DESCRIPTION
Bump MudBlazor from 6.4.1 to 6.6.0
Bump sharpcompress from 0.32.2 to 0.33.0
Bump MongoDB.Driver from 2.18.0 to 2.20.0
Bump Serilog.AspNetCore from 6.1.0 to 7.0.0