### PR TITLE
fix : upgrade dependencies version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       -
         name : Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       -
@@ -86,10 +86,10 @@ jobs:
     steps:
       -
         name : Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -97,12 +97,12 @@ jobs:
       -
         name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/slucky31/mycomicsmanager-web/mycomicsmanager-web
       -
         name: Build and push Docker image MyComicsManagerWeb
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./MyComicsManagerWeb/Dockerfile
@@ -120,10 +120,10 @@ jobs:
     steps:
       -
         name : Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -131,13 +131,13 @@ jobs:
       -
         name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/slucky31/mycomicsmanager-web/mycomicsmanager-api
 
       -
         name: Build and push Docker image MyComicsManagerApi
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./MyComicsManagerApi/Dockerfile

--- a/MyComicsManagerApi.Tests/BedethequeComicHtmlDataParserTest.cs
+++ b/MyComicsManagerApi.Tests/BedethequeComicHtmlDataParserTest.cs
@@ -38,7 +38,7 @@ namespace MyComicsManagerApiTests
             results[ComicDataEnum.ISBN].Should().Be("2847897666");
             results[ComicDataEnum.URL].Should().Be("https://www.bedetheque.com/BD-Goon-Tome-1-Rien-que-de-la-misere-46851.html");
             results[ComicDataEnum.EDITEUR].Should().Be("Delcourt");
-            results[ComicDataEnum.NOTE].Should().Be("4.0");
+            results[ComicDataEnum.NOTE].Should().Be("3.9");
             results[ComicDataEnum.ONESHOT].Should().Be("False");
         }
         
@@ -60,7 +60,7 @@ namespace MyComicsManagerApiTests
             results[ComicDataEnum.ISBN].Should().Be("2847897666");
             results[ComicDataEnum.URL].Should().Be("https://www.bedetheque.com/BD-Goon-Tome-1-Rien-que-de-la-misere-46851.html");
             results[ComicDataEnum.EDITEUR].Should().Be("Delcourt");
-            results[ComicDataEnum.NOTE].Should().Be("4.0");
+            results[ComicDataEnum.NOTE].Should().Be("3.9");
             results[ComicDataEnum.ONESHOT].Should().Be("False");
         }
     }

--- a/MyComicsManagerApi.Tests/MyComicsManagerApiTests.csproj
+++ b/MyComicsManagerApi.Tests/MyComicsManagerApiTests.csproj
@@ -5,7 +5,6 @@
     <IsPackable>false</IsPackable>
     <Version>1.3.1</Version>
     <PackageId>MyComicsManagerApiTests</PackageId>
-    <Version>1.3.0</Version>
     <Authors>Nicolas DUFAUT</Authors>
     <PackageLicenseUrl>https://github.com/slucky31/mycomicsmanager-web/blob/main/LICENSE</PackageLicenseUrl>
   </PropertyGroup>

--- a/MyComicsManagerApi/MyComicsManagerApi.csproj
+++ b/MyComicsManagerApi/MyComicsManagerApi.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.CustomSearchAPI.v1" Version="1.58.0.2455" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
+    <PackageReference Include="Google.Apis.CustomSearchAPI.v1" Version="1.62.0.3106" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.53" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.16" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision" Version="7.0.1" />
     <PackageReference Include="MongoDB.Driver" Version="2.20.0" />

--- a/MyComicsManagerWeb/MyComicsManagerWeb.csproj
+++ b/MyComicsManagerWeb/MyComicsManagerWeb.csproj
@@ -10,13 +10,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.Identity.MongoDbCore" Version="3.1.2" />
-		<PackageReference Include="GitInfo" Version="2.3.0" />
+		<PackageReference Include="GitInfo" Version="3.3.3" />
 		<PackageReference Include="MudBlazor" Version="6.6.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
 		<PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="7.0.0" />
-		<PackageReference Include="Google.Apis.Books.v1" Version="1.60.0.2955" />
+		<PackageReference Include="Google.Apis.Books.v1" Version="1.62.0.2955" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
NuGet :
Bump GitInfo from 2.3.0 to 3.3.3
Bump Google.Apis.CustomSearchAPI.v1 from 1.58.0.2455 to 1.62.0.3106
Bump Google.Apis.Books.v1 from 1.60.0.2955 to 1.62.0.2955
Bump HtmlAgilityPack from 1.11.46 to 1.11.53
Bump Microsoft.AspNetCore.Mvc.NewtonsoftJson from 6.0.16 to 7.0.11

Github Actions :
Bump docker/build-push-action from 4 to 5
Bump docker/login-action from 2 to 3
Bump docker/metadata-action from 4 to 5
Bump actions/checkout from 3 to 4
