### PR TITLE
feat: Add book metadata fields and update schema/UI

### DIFF
--- a/Application/ApplicationDependencyInjection.cs
+++ b/Application/ApplicationDependencyInjection.cs
@@ -1,5 +1,6 @@
 using Application.Abstractions.Messaging;
 using Application.ComicInfoSearch;
+using Application.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Application;

--- a/Application/Books/Create/CreateBookCommand.cs
+++ b/Application/Books/Create/CreateBookCommand.cs
@@ -9,5 +9,9 @@ public record CreateBookCommand(
     string ISBN,
     int VolumeNumber = 1,
     string ImageLink = "",
-    int Rating = 0
+    int Rating = 0,
+    string Authors = "",
+    string Publishers = "",
+    DateOnly? PublishDate = null,
+    int? NumberOfPages = null
 ) : ICommand<Book>;

--- a/Application/Books/Create/CreateBookCommandHandler.cs
+++ b/Application/Books/Create/CreateBookCommandHandler.cs
@@ -35,7 +35,8 @@ public sealed class CreateBookCommandHandler(IBookRepository bookRepository, IUn
         }
 
         // Create Book
-        var book = Book.Create(request.Serie, request.Title, normalizedIsbn, request.VolumeNumber, request.ImageLink, request.Rating);
+        var book = Book.Create(request.Serie, request.Title, normalizedIsbn, request.VolumeNumber, request.ImageLink, request.Rating,
+            request.Authors, request.Publishers, request.PublishDate, request.NumberOfPages);
 
         // If a rating is provided, the book has been read, so add a reading date
         if (request.Rating > 0)

--- a/Application/Books/Update/UpdateBookCommand.cs
+++ b/Application/Books/Update/UpdateBookCommand.cs
@@ -10,5 +10,9 @@ public record UpdateBookCommand(
     string ISBN,
     int VolumeNumber,
     string ImageLink,
-    int Rating
+    int Rating,
+    string Authors = "",
+    string Publishers = "",
+    DateOnly? PublishDate = null,
+    int? NumberOfPages = null
 ) : ICommand<Book>;

--- a/Application/Books/Update/UpdateBookCommandHandler.cs
+++ b/Application/Books/Update/UpdateBookCommandHandler.cs
@@ -41,7 +41,7 @@ public sealed class UpdateBookCommandHandler(IBookRepository bookRepository, IUn
         }
 
         // Update the book
-        book.Update(request.Serie, request.Title, request.ISBN, request.VolumeNumber, request.ImageLink, request.Rating,
+        book.Update(request.Serie, request.Title, normalizedIsbn, request.VolumeNumber, request.ImageLink, request.Rating,
             request.Authors, request.Publishers, request.PublishDate, request.NumberOfPages);
 
         bookRepository.Update(book);

--- a/Application/Books/Update/UpdateBookCommandHandler.cs
+++ b/Application/Books/Update/UpdateBookCommandHandler.cs
@@ -41,7 +41,8 @@ public sealed class UpdateBookCommandHandler(IBookRepository bookRepository, IUn
         }
 
         // Update the book
-        book.Update(request.Serie, request.Title, request.ISBN, request.VolumeNumber, request.ImageLink, request.Rating);
+        book.Update(request.Serie, request.Title, request.ISBN, request.VolumeNumber, request.ImageLink, request.Rating,
+            request.Authors, request.Publishers, request.PublishDate, request.NumberOfPages);
 
         bookRepository.Update(book);
         await unitOfWork.SaveChangesAsync(cancellationToken);

--- a/Application/ComicInfoSearch/ComicSearchService.cs
+++ b/Application/ComicInfoSearch/ComicSearchService.cs
@@ -142,7 +142,7 @@ public class ComicSearchService : IComicSearchService
                 if (int.TryParse(match.Groups[2].Value, out var vol))
                 {
                     volumeNumber = vol;
-                }                
+                }
                 break;
             }
         }

--- a/Application/ComicInfoSearch/ComicSearchService.cs
+++ b/Application/ComicInfoSearch/ComicSearchService.cs
@@ -85,6 +85,11 @@ public partial class ComicSearchService : IComicSearchService
             Log.Error(ex, "Timeout searching for ISBN {Isbn}", isbn);
             return CreateNotFoundResult(isbn);
         }
+        catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+        {
+            Log.Warning(ex, "Search cancelled for ISBN {Isbn}", isbn);
+            return CreateNotFoundResult(isbn);
+        }
     }
 
     private async Task<string> UploadCoverToCloudinaryAsync(Uri coverUrl, string isbn, CancellationToken cancellationToken)

--- a/Application/ComicInfoSearch/ComicSearchService.cs
+++ b/Application/ComicInfoSearch/ComicSearchService.cs
@@ -215,12 +215,6 @@ public partial class ComicSearchService : IComicSearchService
             return DateOnly.FromDateTime(dateTime);
         }
 
-        // If only a year is provided as a number
-        if (int.TryParse(dateString.Trim(), out var year) && year >= 1000 && year <= 9999)
-        {
-            return new DateOnly(year, 1, 1);
-        }
-
         Log.Warning("Unable to parse publish date: {DateString}", dateString);
         return null;
     }

--- a/Application/ComicInfoSearch/ComicSearchService.cs
+++ b/Application/ComicInfoSearch/ComicSearchService.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
+using Application.Interfaces;
 using Microsoft.Extensions.Options;
 
 namespace Application.ComicInfoSearch;
@@ -135,7 +136,7 @@ public class ComicSearchService : IComicSearchService
 
         foreach (var pattern in patterns)
         {
-            var match = Regex.Match(fullTitle, pattern, RegexOptions.IgnoreCase);
+            var match = Regex.Match(fullTitle, pattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(1));
             if (match.Success)
             {
                 serie = match.Groups[1].Value.Trim();

--- a/Application/ComicInfoSearch/ComicSearchService.cs
+++ b/Application/ComicInfoSearch/ComicSearchService.cs
@@ -54,7 +54,7 @@ public class ComicSearchService : IComicSearchService
             // Parse publish date from OpenLibrary format
             var publishDate = ParsePublishDate(result.PublishDate);
 
-            Log.Information("Found book: {Title} - {Serie} Vol.{Volume}", result.Subtitle, serie, volumeNumber);
+            Log.Information("Found book: {Title} - {Serie} Vol.{Volume}", title, serie, volumeNumber);
 
             return new ComicSearchResult(
                 Title: title,

--- a/Application/ComicInfoSearch/IComicSearchService.cs
+++ b/Application/ComicInfoSearch/IComicSearchService.cs
@@ -7,6 +7,10 @@ public record ComicSearchResult(
     string Isbn,
     int VolumeNumber,
     string ImageUrl,
+    string Authors,
+    string Publishers,
+    DateOnly? PublishDate,
+    int? NumberOfPages,
     bool Found
 );
 #pragma warning restore CA1054, CA1056

--- a/Application/ComicInfoSearch/OpenLibraryService.cs
+++ b/Application/ComicInfoSearch/OpenLibraryService.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Application.Interfaces;
 
 namespace Application.ComicInfoSearch;
 

--- a/Application/Interfaces/ICloudinaryService.cs
+++ b/Application/Interfaces/ICloudinaryService.cs
@@ -1,4 +1,4 @@
-namespace Application.ComicInfoSearch;
+namespace Application.Interfaces;
 
 public record CloudinaryUploadResult(
     Uri? Url,

--- a/Application/Interfaces/IComicSearchService.cs
+++ b/Application/Interfaces/IComicSearchService.cs
@@ -1,4 +1,4 @@
-namespace Application.ComicInfoSearch;
+namespace Application.Interfaces;
 
 #pragma warning disable CA1054, CA1056 // URI parameters/properties should not be strings
 public record ComicSearchResult(

--- a/Application/Interfaces/IOpenLibraryService.cs
+++ b/Application/Interfaces/IOpenLibraryService.cs
@@ -1,4 +1,4 @@
-namespace Application.ComicInfoSearch;
+namespace Application.Interfaces;
 
 public record OpenLibraryBookResult(
     string Title,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="AwesomeAssertions" Version="9.3.0" />
     <PackageVersion Include="bunit" Version="2.5.3" />
     <PackageVersion Include="CloudinaryDotNet" Version="1.27.2" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="Google.Apis.CustomSearchAPI.v1" Version="1.68.0.3520" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />

--- a/Domain/Books/Book.cs
+++ b/Domain/Books/Book.cs
@@ -27,28 +27,17 @@ public class Book : Entity<Guid>
     private readonly List<ReadingDate> _readingDates = [];
     public IReadOnlyList<ReadingDate> ReadingDates => _readingDates.AsReadOnly();
 
-    public static Book Create(string series, string title, string isbn)
-    {
-        return Create(series, title, isbn, 1, "", 0, "", "", null, null);
-    }
-
-    public static Book Create(string series, string title, string isbn, int volumeNumber)
-    {
-        return Create(series, title, isbn, volumeNumber, "", 0, "", "", null, null);
-    }
-
-    public static Book Create(string series, string title, string isbn, int volumeNumber, string imageLink)
-    {
-        return Create(series, title, isbn, volumeNumber, imageLink, 0, "", "", null, null);
-    }
-
-    public static Book Create(string series, string title, string isbn, int volumeNumber, string imageLink, int rating)
-    {
-        return Create(series, title, isbn, volumeNumber, imageLink, rating, "", "", null, null);
-    }
-
-    public static Book Create(string series, string title, string isbn, int volumeNumber, string imageLink, int rating,
-        string authors, string publishers, DateOnly? publishDate, int? numberOfPages)
+    public static Book Create(
+        string series,
+        string title,
+        string isbn,
+        int volumeNumber = 1,
+        string imageLink = "",
+        int rating = 0,
+        string authors = "",
+        string publishers = "",
+        DateOnly? publishDate = null,
+        int? numberOfPages = null)
     {
         var book = new Book
         {
@@ -67,13 +56,17 @@ public class Book : Entity<Guid>
         return book;
     }
 
-    public void Update(string series, string title, string isbn, int volumeNumber, string imageLink, int rating)
-    {
-        Update(series, title, isbn, volumeNumber, imageLink, rating, Authors, Publishers, PublishDate, NumberOfPages);
-    }
-
-    public void Update(string series, string title, string isbn, int volumeNumber, string imageLink, int rating,
-        string authors, string publishers, DateOnly? publishDate, int? numberOfPages)
+    public void Update(
+        string series,
+        string title,
+        string isbn,
+        int volumeNumber,
+        string imageLink,
+        int rating,
+        string authors = "",
+        string publishers = "",
+        DateOnly? publishDate = null,
+        int? numberOfPages = null)
     {
         Serie = series;
         Title = title;

--- a/Domain/Books/Book.cs
+++ b/Domain/Books/Book.cs
@@ -16,25 +16,39 @@ public class Book : Entity<Guid>
 
     public int Rating { get; protected set; }
 
+    public string Authors { get; protected set; } = string.Empty;
+
+    public string Publishers { get; protected set; } = string.Empty;
+
+    public DateOnly? PublishDate { get; protected set; }
+
+    public int? NumberOfPages { get; protected set; }
+
     private readonly List<ReadingDate> _readingDates = [];
     public IReadOnlyList<ReadingDate> ReadingDates => _readingDates.AsReadOnly();
 
     public static Book Create(string series, string title, string isbn)
     {
-        return Create(series, title, isbn, 1, "", 0);
+        return Create(series, title, isbn, 1, "", 0, "", "", null, null);
     }
 
     public static Book Create(string series, string title, string isbn, int volumeNumber)
     {
-        return Create(series, title, isbn, volumeNumber, "", 0);
+        return Create(series, title, isbn, volumeNumber, "", 0, "", "", null, null);
     }
 
     public static Book Create(string series, string title, string isbn, int volumeNumber, string imageLink)
     {
-        return Create(series, title, isbn, volumeNumber, imageLink, 0);
+        return Create(series, title, isbn, volumeNumber, imageLink, 0, "", "", null, null);
     }
 
     public static Book Create(string series, string title, string isbn, int volumeNumber, string imageLink, int rating)
+    {
+        return Create(series, title, isbn, volumeNumber, imageLink, rating, "", "", null, null);
+    }
+
+    public static Book Create(string series, string title, string isbn, int volumeNumber, string imageLink, int rating,
+        string authors, string publishers, DateOnly? publishDate, int? numberOfPages)
     {
         var book = new Book
         {
@@ -44,12 +58,22 @@ public class Book : Entity<Guid>
             ISBN = isbn,
             VolumeNumber = volumeNumber,
             ImageLink = imageLink,
-            Rating = rating
+            Rating = rating,
+            Authors = authors,
+            Publishers = publishers,
+            PublishDate = publishDate,
+            NumberOfPages = numberOfPages
         };
         return book;
     }
 
     public void Update(string series, string title, string isbn, int volumeNumber, string imageLink, int rating)
+    {
+        Update(series, title, isbn, volumeNumber, imageLink, rating, Authors, Publishers, PublishDate, NumberOfPages);
+    }
+
+    public void Update(string series, string title, string isbn, int volumeNumber, string imageLink, int rating,
+        string authors, string publishers, DateOnly? publishDate, int? numberOfPages)
     {
         Serie = series;
         Title = title;
@@ -57,6 +81,10 @@ public class Book : Entity<Guid>
         VolumeNumber = volumeNumber;
         ImageLink = imageLink;
         Rating = rating;
+        Authors = authors;
+        Publishers = publishers;
+        PublishDate = publishDate;
+        NumberOfPages = numberOfPages;
     }
 
     public void AddReadingDate(DateTime date)

--- a/Domain/Books/BookConstants.cs
+++ b/Domain/Books/BookConstants.cs
@@ -1,0 +1,11 @@
+namespace Domain.Books;
+
+public static class BookConstants
+{
+    public const int MaxSerieLength = 200;
+    public const int MaxTitleLength = 200;
+    public const int MaxIsbnLength = 20;
+    public const int MaxImageLinkLength = 500;
+    public const int MaxAuthorsLength = 200;
+    public const int MaxPublishersLength = 200;
+}

--- a/Persistence/ApplicationDbContext.cs
+++ b/Persistence/ApplicationDbContext.cs
@@ -27,6 +27,12 @@ public class ApplicationDbContext(DbContextOptions options) : DbContext(options)
             modelBuilder.Entity<User>().ToTable("Users");
 
             modelBuilder.Entity<Book>().ToTable("Books");
+            modelBuilder.Entity<Book>().Property(b => b.Serie).HasMaxLength(BookConstants.MaxSerieLength);
+            modelBuilder.Entity<Book>().Property(b => b.Title).HasMaxLength(BookConstants.MaxTitleLength);
+            modelBuilder.Entity<Book>().Property(b => b.ISBN).HasMaxLength(BookConstants.MaxIsbnLength);
+            modelBuilder.Entity<Book>().Property(b => b.ImageLink).HasMaxLength(BookConstants.MaxImageLinkLength);
+            modelBuilder.Entity<Book>().Property(b => b.Authors).HasMaxLength(BookConstants.MaxAuthorsLength);
+            modelBuilder.Entity<Book>().Property(b => b.Publishers).HasMaxLength(BookConstants.MaxPublishersLength);
             modelBuilder.Entity<Book>()
                 .HasMany(b => b.ReadingDates)
                 .WithOne()

--- a/Persistence/Migrations/20260201111729_RemoveNoteFromReadingDate.cs
+++ b/Persistence/Migrations/20260201111729_RemoveNoteFromReadingDate.cs
@@ -1,29 +1,28 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace Persistence.Migrations
+namespace Persistence.Migrations;
+
+/// <inheritdoc />
+public partial class RemoveNoteFromReadingDate : Migration
 {
     /// <inheritdoc />
-    public partial class RemoveNoteFromReadingDate : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropColumn(
-                name: "Note",
-                table: "ReadingDates");
-        }
+        migrationBuilder.DropColumn(
+            name: "Note",
+            table: "ReadingDates");
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AddColumn<string>(
-                name: "Note",
-                table: "ReadingDates",
-                type: "text",
-                nullable: false,
-                defaultValue: "");
-        }
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "Note",
+            table: "ReadingDates",
+            type: "text",
+            nullable: false,
+            defaultValue: "");
     }
 }

--- a/Persistence/Migrations/20260207133302_AddBookMetadata.Designer.cs
+++ b/Persistence/Migrations/20260207133302_AddBookMetadata.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Persistence;
@@ -11,9 +12,11 @@ using Persistence;
 namespace Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260207133302_AddBookMetadata")]
+    partial class AddBookMetadata
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Persistence/Migrations/20260207133302_AddBookMetadata.cs
+++ b/Persistence/Migrations/20260207133302_AddBookMetadata.cs
@@ -1,61 +1,59 @@
-﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace Persistence.Migrations
+namespace Persistence.Migrations;
+
+/// <inheritdoc />
+public partial class AddBookMetadata : Migration
 {
     /// <inheritdoc />
-    public partial class AddBookMetadata : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AddColumn<string>(
-                name: "Authors",
-                table: "Books",
-                type: "text",
-                nullable: false,
-                defaultValue: "");
+        migrationBuilder.AddColumn<string>(
+            name: "Authors",
+            table: "Books",
+            type: "text",
+            nullable: false,
+            defaultValue: "");
 
-            migrationBuilder.AddColumn<int>(
-                name: "NumberOfPages",
-                table: "Books",
-                type: "integer",
-                nullable: true);
+        migrationBuilder.AddColumn<int>(
+            name: "NumberOfPages",
+            table: "Books",
+            type: "integer",
+            nullable: true);
 
-            migrationBuilder.AddColumn<DateOnly>(
-                name: "PublishDate",
-                table: "Books",
-                type: "date",
-                nullable: true);
+        migrationBuilder.AddColumn<DateOnly>(
+            name: "PublishDate",
+            table: "Books",
+            type: "date",
+            nullable: true);
 
-            migrationBuilder.AddColumn<string>(
-                name: "Publishers",
-                table: "Books",
-                type: "text",
-                nullable: false,
-                defaultValue: "");
-        }
+        migrationBuilder.AddColumn<string>(
+            name: "Publishers",
+            table: "Books",
+            type: "text",
+            nullable: false,
+            defaultValue: "");
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropColumn(
-                name: "Authors",
-                table: "Books");
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "Authors",
+            table: "Books");
 
-            migrationBuilder.DropColumn(
-                name: "NumberOfPages",
-                table: "Books");
+        migrationBuilder.DropColumn(
+            name: "NumberOfPages",
+            table: "Books");
 
-            migrationBuilder.DropColumn(
-                name: "PublishDate",
-                table: "Books");
+        migrationBuilder.DropColumn(
+            name: "PublishDate",
+            table: "Books");
 
-            migrationBuilder.DropColumn(
-                name: "Publishers",
-                table: "Books");
-        }
+        migrationBuilder.DropColumn(
+            name: "Publishers",
+            table: "Books");
     }
 }

--- a/Persistence/Migrations/20260207133302_AddBookMetadata.cs
+++ b/Persistence/Migrations/20260207133302_AddBookMetadata.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBookMetadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Authors",
+                table: "Books",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "NumberOfPages",
+                table: "Books",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "PublishDate",
+                table: "Books",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Publishers",
+                table: "Books",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Authors",
+                table: "Books");
+
+            migrationBuilder.DropColumn(
+                name: "NumberOfPages",
+                table: "Books");
+
+            migrationBuilder.DropColumn(
+                name: "PublishDate",
+                table: "Books");
+
+            migrationBuilder.DropColumn(
+                name: "Publishers",
+                table: "Books");
+        }
+    }
+}

--- a/Persistence/Migrations/20260207181318_AddBookStringMaxLengths.Designer.cs
+++ b/Persistence/Migrations/20260207181318_AddBookStringMaxLengths.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Persistence;
@@ -11,9 +12,11 @@ using Persistence;
 namespace Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260207181318_AddBookStringMaxLengths")]
+    partial class AddBookStringMaxLengths
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Persistence/Migrations/20260207181318_AddBookStringMaxLengths.cs
+++ b/Persistence/Migrations/20260207181318_AddBookStringMaxLengths.cs
@@ -1,0 +1,125 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistence.Migrations;
+
+/// <inheritdoc />
+public partial class AddBookStringMaxLengths : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<string>(
+            name: "Title",
+            table: "Books",
+            type: "character varying(200)",
+            maxLength: 200,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "text");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "Serie",
+            table: "Books",
+            type: "character varying(200)",
+            maxLength: 200,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "text");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "Publishers",
+            table: "Books",
+            type: "character varying(200)",
+            maxLength: 200,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "text");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "ImageLink",
+            table: "Books",
+            type: "character varying(500)",
+            maxLength: 500,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "text");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "ISBN",
+            table: "Books",
+            type: "character varying(20)",
+            maxLength: 20,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "text");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "Authors",
+            table: "Books",
+            type: "character varying(200)",
+            maxLength: 200,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "text");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<string>(
+            name: "Title",
+            table: "Books",
+            type: "text",
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "character varying(200)",
+            oldMaxLength: 200);
+
+        migrationBuilder.AlterColumn<string>(
+            name: "Serie",
+            table: "Books",
+            type: "text",
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "character varying(200)",
+            oldMaxLength: 200);
+
+        migrationBuilder.AlterColumn<string>(
+            name: "Publishers",
+            table: "Books",
+            type: "text",
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "character varying(200)",
+            oldMaxLength: 200);
+
+        migrationBuilder.AlterColumn<string>(
+            name: "ImageLink",
+            table: "Books",
+            type: "text",
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "character varying(500)",
+            oldMaxLength: 500);
+
+        migrationBuilder.AlterColumn<string>(
+            name: "ISBN",
+            table: "Books",
+            type: "text",
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "character varying(20)",
+            oldMaxLength: 20);
+
+        migrationBuilder.AlterColumn<string>(
+            name: "Authors",
+            table: "Books",
+            type: "text",
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "character varying(200)",
+            oldMaxLength: 200);
+    }
+}

--- a/Persistence/ProjectDependencyInjection.cs
+++ b/Persistence/ProjectDependencyInjection.cs
@@ -8,7 +8,6 @@ using Domain.Users;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Persistence.LocalStorage;
 using Persistence.Queries;
 using Persistence.Repositories;

--- a/Persistence/Services/CloudinaryService.cs
+++ b/Persistence/Services/CloudinaryService.cs
@@ -1,4 +1,5 @@
 using Application.ComicInfoSearch;
+using Application.Interfaces;
 using CloudinaryDotNet;
 using CloudinaryDotNet.Actions;
 using Microsoft.Extensions.Options;

--- a/TODO.md
+++ b/TODO.md
@@ -63,3 +63,22 @@ Quel style de design préférez-vous pour les cartes de livres?
      Vue liste avec plus d'informations visibles, idéale pour les grandes collections
   4. Masonry grid
      Grille asymétrique type Pinterest avec tailles variables selon le contenu
+
+
+     // Minimal usage
+var book = Book.Create("Series", "Title", "ISBN");
+
+// With named parameters for metadata
+var book = Book.Create("Watchmen", "Watchmen", "9781401245252", 
+    authors: "Alan Moore, Dave Gibbons", 
+    publishers: "DC Comics");
+
+// With all metadata
+var book = Book.Create("Saga", "Chapter One", "9781607066019", 
+    volumeNumber: 1, imageLink: "http://example.com/saga.jpg", rating: 5,
+    authors: "Brian K. Vaughan, Fiona Staples", publishers: "Image Comics",
+    publishDate: new DateOnly(2012, 10, 10), numberOfPages: 160);
+
+// Update with metadata
+book.Update("Saga", "Chapter One", "9781607066019", 1, "url", 5,
+    "New Author", "New Publisher", new DateOnly(2024, 1, 1), 200);

--- a/Web/Components/Pages/Books/AddBookForm.razor
+++ b/Web/Components/Pages/Books/AddBookForm.razor
@@ -185,7 +185,7 @@
 
         try
         {
-            var result = await BooksService.Create(
+            var request = new CreateBookRequest(
                 _bookModel.Serie,
                 _bookModel.Title,
                 _bookModel.ISBN,
@@ -197,6 +197,8 @@
                 _bookModel.PublishDate,
                 _bookModel.NumberOfPages
             );
+
+            var result = await BooksService.Create(request);
 
             if (result.IsSuccess)
             {

--- a/Web/Components/Pages/Books/AddBookForm.razor
+++ b/Web/Components/Pages/Books/AddBookForm.razor
@@ -2,6 +2,7 @@
 @rendermode InteractiveServer
 
 @using Application.ComicInfoSearch
+@using Application.Interfaces
 @using Microsoft.AspNetCore.Components
 @using Web.Services
 @using Web.Validators

--- a/Web/Components/Pages/Books/AddBookForm.razor
+++ b/Web/Components/Pages/Books/AddBookForm.razor
@@ -137,7 +137,11 @@
                         ISBN = _searchResult.Isbn,
                         VolumeNumber = _searchResult.VolumeNumber,
                         ImageLink = _searchResult.ImageUrl,
-                        Rating = 0
+                        Rating = 0,
+                        Authors = _searchResult.Authors,
+                        Publishers = _searchResult.Publishers,
+                        PublishDate = _searchResult.PublishDate,
+                        NumberOfPages = _searchResult.NumberOfPages
                     };
                     Snackbar.Add($"Found: {_searchResult.Title}", Severity.Success);
                 }
@@ -187,7 +191,11 @@
                 _bookModel.ISBN,
                 _bookModel.VolumeNumber,
                 _bookModel.ImageLink,
-                _bookModel.Rating
+                _bookModel.Rating,
+                _bookModel.Authors,
+                _bookModel.Publishers,
+                _bookModel.PublishDate,
+                _bookModel.NumberOfPages
             );
 
             if (result.IsSuccess)

--- a/Web/Components/Pages/Books/BookDetail.razor
+++ b/Web/Components/Pages/Books/BookDetail.razor
@@ -179,6 +179,54 @@
                                 </div>
                             </div>
 
+                            @* Authors *@
+                            @if (!string.IsNullOrEmpty(_book.Authors))
+                            {
+                                <div class="book-detail-info-item">
+                                    <MudIcon Icon="@Icons.Material.Filled.Person" Color="Color.Secondary" />
+                                    <div>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">Authors</MudText>
+                                        <MudText Typo="Typo.body1">@_book.Authors</MudText>
+                                    </div>
+                                </div>
+                            }
+
+                            @* Publishers *@
+                            @if (!string.IsNullOrEmpty(_book.Publishers))
+                            {
+                                <div class="book-detail-info-item">
+                                    <MudIcon Icon="@Icons.Material.Filled.Business" Color="Color.Secondary" />
+                                    <div>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">Publishers</MudText>
+                                        <MudText Typo="Typo.body1">@_book.Publishers</MudText>
+                                    </div>
+                                </div>
+                            }
+
+                            @* Publish Date *@
+                            @if (_book.PublishDate.HasValue)
+                            {
+                                <div class="book-detail-info-item">
+                                    <MudIcon Icon="@Icons.Material.Filled.Event" Color="Color.Secondary" />
+                                    <div>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">Publish Date</MudText>
+                                        <MudText Typo="Typo.body1">@_book.PublishDate.Value.ToString("dd/MM/yyyy")</MudText>
+                                    </div>
+                                </div>
+                            }
+
+                            @* Number of Pages *@
+                            @if (_book.NumberOfPages.HasValue)
+                            {
+                                <div class="book-detail-info-item">
+                                    <MudIcon Icon="@Icons.Material.Filled.Description" Color="Color.Secondary" />
+                                    <div>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">Number of Pages</MudText>
+                                        <MudText Typo="Typo.body1">@_book.NumberOfPages pages</MudText>
+                                    </div>
+                                </div>
+                            }
+
                             @* Reading status *@
                             <div class="book-detail-info-item">
                                 <MudIcon Icon="@(_book.ReadingDates.Any() ? Icons.Material.Filled.CheckCircle : Icons.Material.Outlined.RadioButtonUnchecked)"

--- a/Web/Components/Pages/Books/BookDetail.razor
+++ b/Web/Components/Pages/Books/BookDetail.razor
@@ -237,7 +237,7 @@
                                     {
                                         var lastRead = _book.ReadingDates.MaxBy(rd => rd.Date);
                                         <MudText Typo="Typo.body1" Color="Color.Success">
-                                            Read on @lastRead!.Date.ToString("MMMM d, yyyy")
+                                            Read on @lastRead!.Date.ToString("dd/MM/yyyy")
                                         </MudText>
                                     }
                                     else
@@ -252,7 +252,7 @@
                                 <MudIcon Icon="@Icons.Material.Filled.CalendarMonth" Color="Color.Secondary" />
                                 <div>
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">Added to Collection</MudText>
-                                    <MudText Typo="Typo.body1">@_book.CreatedOnUtc.ToString("MMMM d, yyyy")</MudText>
+                                    <MudText Typo="Typo.body1">@_book.CreatedOnUtc.ToString("dd/MM/yyyy")</MudText>
                                 </div>
                             </div>
 
@@ -263,7 +263,7 @@
                                     <MudIcon Icon="@Icons.Material.Filled.EditCalendar" Color="Color.Secondary" />
                                     <div>
                                         <MudText Typo="Typo.caption" Color="Color.Secondary">Last Modified</MudText>
-                                        <MudText Typo="Typo.body1">@_book.ModifiedOnUtc.Value.ToString("MMMM d, yyyy")</MudText>
+                                        <MudText Typo="Typo.body1">@_book.ModifiedOnUtc.Value.ToString("dd/MM/yyyy")</MudText>
                                     </div>
                                 </div>
                             }

--- a/Web/Components/Pages/Books/BookForm.razor
+++ b/Web/Components/Pages/Books/BookForm.razor
@@ -100,6 +100,49 @@
                               Adornment="Adornment.Start"
                               AdornmentIcon="@Icons.Material.Filled.Image"
                               HelperText="Paste a URL to the book cover image" />
+
+                @* Authors *@
+                <MudTextField @bind-Value="Model.Authors"
+                              For="@(() => Model.Authors)"
+                              Immediate="true"
+                              Label="Authors"
+                              Variant="Variant.Outlined"
+                              Adornment="Adornment.Start"
+                              AdornmentIcon="@Icons.Material.Filled.Person"
+                              HelperText="Comma-separated list of authors" />
+
+                @* Publishers *@
+                <MudTextField @bind-Value="Model.Publishers"
+                              For="@(() => Model.Publishers)"
+                              Immediate="true"
+                              Label="Publishers"
+                              Variant="Variant.Outlined"
+                              Adornment="Adornment.Start"
+                              AdornmentIcon="@Icons.Material.Filled.Business"
+                              HelperText="Comma-separated list of publishers" />
+
+                @* Publish Date and Number of Pages in a row *@
+                <MudGrid Spacing="2">
+                    <MudItem xs="7">
+                        <MudDatePicker @bind-Date="PublishDateTime"
+                                       Label="Publish Date"
+                                       Variant="Variant.Outlined"
+                                       Editable="true"
+                                       DateFormat="dd/MM/yyyy"
+                                       Placeholder="dd/MM/yyyy"
+                                       Adornment="Adornment.Start"
+                                       AdornmentIcon="@Icons.Material.Filled.CalendarMonth" />
+                    </MudItem>
+                    <MudItem xs="5">
+                        <MudNumericField @bind-Value="Model.NumberOfPages"
+                                         For="@(() => Model.NumberOfPages)"
+                                         Label="Pages"
+                                         Variant="Variant.Outlined"
+                                         Min="1"
+                                         Adornment="Adornment.Start"
+                                         AdornmentIcon="@Icons.Material.Filled.Description" />
+                    </MudItem>
+                </MudGrid>
             </MudStack>
         </MudItem>
     </MudGrid>
@@ -114,6 +157,13 @@
 
     private readonly BookValidator _bookValidator = new();
     private MudForm _form = default!;
+
+    // Conversion property for MudDatePicker (DateTime?) to DateOnly?
+    private DateTime? PublishDateTime
+    {
+        get => Model.PublishDate?.ToDateTime(TimeOnly.MinValue);
+        set => Model.PublishDate = value.HasValue ? DateOnly.FromDateTime(value.Value) : null;
+    }
 
     public async Task<bool> ValidateAsync()
     {

--- a/Web/Components/Pages/Books/EditBook.razor
+++ b/Web/Components/Pages/Books/EditBook.razor
@@ -168,7 +168,7 @@
 
         try
         {
-            var result = await BooksService.Update(
+            var request = new UpdateBookRequest(
                 _bookModel.Id.ToString(),
                 _bookModel.Serie,
                 _bookModel.Title,
@@ -181,6 +181,8 @@
                 _bookModel.PublishDate,
                 _bookModel.NumberOfPages
             );
+
+            var result = await BooksService.Update(request);
 
             if (result.IsSuccess)
             {

--- a/Web/Components/Pages/Books/EditBook.razor
+++ b/Web/Components/Pages/Books/EditBook.razor
@@ -175,7 +175,11 @@
                 _bookModel.ISBN,
                 _bookModel.VolumeNumber,
                 _bookModel.ImageLink,
-                _bookModel.Rating
+                _bookModel.Rating,
+                _bookModel.Authors,
+                _bookModel.Publishers,
+                _bookModel.PublishDate,
+                _bookModel.NumberOfPages
             );
 
             if (result.IsSuccess)

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -1,5 +1,6 @@
 using Application;
 using Application.ComicInfoSearch;
+using Application.Interfaces;
 using Ardalis.GuardClauses;
 using Auth0.AspNetCore.Authentication;
 using HealthChecks.ApplicationStatus.DependencyInjection;

--- a/Web/Services/BooksService.cs
+++ b/Web/Services/BooksService.cs
@@ -40,19 +40,31 @@ public class BooksService(
 
     public async Task<Result<Book>> Create(string series, string title, string isbn, int volumeNumber, string imageLink, int rating, CancellationToken cancellationToken = default)
     {
-        var command = new CreateBookCommand(series, title, isbn, volumeNumber, imageLink, rating);
+        return await Create(series, title, isbn, volumeNumber, imageLink, rating, "", "", null, null, cancellationToken);
+    }
+
+    public async Task<Result<Book>> Create(string series, string title, string isbn, int volumeNumber, string imageLink, int rating,
+        string authors, string publishers, DateOnly? publishDate, int? numberOfPages, CancellationToken cancellationToken = default)
+    {
+        var command = new CreateBookCommand(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
 
         return await createBookHandler.Handle(command, cancellationToken);
     }
 
     public async Task<Result<Book>> Update(string? id, string series, string title, string isbn, int volumeNumber, string imageLink, int rating, CancellationToken cancellationToken = default)
     {
+        return await Update(id, series, title, isbn, volumeNumber, imageLink, rating, "", "", null, null, cancellationToken);
+    }
+
+    public async Task<Result<Book>> Update(string? id, string series, string title, string isbn, int volumeNumber, string imageLink, int rating,
+        string authors, string publishers, DateOnly? publishDate, int? numberOfPages, CancellationToken cancellationToken = default)
+    {
         if (!Guid.TryParse(id, out var guidId))
         {
             return BooksError.ValidationError;
         }
 
-        var command = new UpdateBookCommand(guidId, series, title, isbn, volumeNumber, imageLink, rating);
+        var command = new UpdateBookCommand(guidId, series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
 
         return await updateBookHandler.Handle(command, cancellationToken);
     }

--- a/Web/Services/BooksService.cs
+++ b/Web/Services/BooksService.cs
@@ -53,7 +53,21 @@ public class BooksService(
 
     public async Task<Result<Book>> Update(string? id, string series, string title, string isbn, int volumeNumber, string imageLink, int rating, CancellationToken cancellationToken = default)
     {
-        return await Update(id, series, title, isbn, volumeNumber, imageLink, rating, "", "", null, null, cancellationToken);
+        if (!Guid.TryParse(id, out var guidId))
+        {
+            return BooksError.ValidationError;
+        }
+
+        var query = new GetBookByIdQuery(guidId);
+        var existingBookResult = await getBookByIdHandler.Handle(query, cancellationToken);
+        if (existingBookResult.IsFailure)
+        {
+            return existingBookResult.Error!;
+        }
+
+        var existingBook = existingBookResult.Value!;
+        return await Update(id, series, title, isbn, volumeNumber, imageLink, rating,
+            existingBook.Authors, existingBook.Publishers, existingBook.PublishDate, existingBook.NumberOfPages, cancellationToken);
     }
 
     public async Task<Result<Book>> Update(string? id, string series, string title, string isbn, int volumeNumber, string imageLink, int rating,

--- a/Web/Services/BooksService.cs
+++ b/Web/Services/BooksService.cs
@@ -28,57 +28,42 @@ public class BooksService(
         return await getBookByIdHandler.Handle(query, CancellationToken.None);
     }
 
-    public async Task<Result<Book>> Create(string series, string title, string isbn)
+    public async Task<Result<Book>> Create(CreateBookRequest request, CancellationToken cancellationToken = default)
     {
-        return await Create(series, title, isbn, 1, "", 0);
-    }
-
-    public async Task<Result<Book>> Create(string series, string title, string isbn, int volumeNumber)
-    {
-        return await Create(series, title, isbn, volumeNumber, "", 0);
-    }
-
-    public async Task<Result<Book>> Create(string series, string title, string isbn, int volumeNumber, string imageLink, int rating, CancellationToken cancellationToken = default)
-    {
-        return await Create(series, title, isbn, volumeNumber, imageLink, rating, "", "", null, null, cancellationToken);
-    }
-
-    public async Task<Result<Book>> Create(string series, string title, string isbn, int volumeNumber, string imageLink, int rating,
-        string authors, string publishers, DateOnly? publishDate, int? numberOfPages, CancellationToken cancellationToken = default)
-    {
-        var command = new CreateBookCommand(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+        var command = new CreateBookCommand(
+            request.Series,
+            request.Title,
+            request.Isbn,
+            request.VolumeNumber,
+            request.ImageLink,
+            request.Rating,
+            request.Authors,
+            request.Publishers,
+            request.PublishDate,
+            request.NumberOfPages);
 
         return await createBookHandler.Handle(command, cancellationToken);
     }
 
-    public async Task<Result<Book>> Update(string? id, string series, string title, string isbn, int volumeNumber, string imageLink, int rating, CancellationToken cancellationToken = default)
+    public async Task<Result<Book>> Update(UpdateBookRequest request, CancellationToken cancellationToken = default)
     {
-        if (!Guid.TryParse(id, out var guidId))
+        if (!Guid.TryParse(request.Id, out var guidId))
         {
             return BooksError.ValidationError;
         }
 
-        var query = new GetBookByIdQuery(guidId);
-        var existingBookResult = await getBookByIdHandler.Handle(query, cancellationToken);
-        if (existingBookResult.IsFailure)
-        {
-            return existingBookResult.Error!;
-        }
-
-        var existingBook = existingBookResult.Value!;
-        return await Update(id, series, title, isbn, volumeNumber, imageLink, rating,
-            existingBook.Authors, existingBook.Publishers, existingBook.PublishDate, existingBook.NumberOfPages, cancellationToken);
-    }
-
-    public async Task<Result<Book>> Update(string? id, string series, string title, string isbn, int volumeNumber, string imageLink, int rating,
-        string authors, string publishers, DateOnly? publishDate, int? numberOfPages, CancellationToken cancellationToken = default)
-    {
-        if (!Guid.TryParse(id, out var guidId))
-        {
-            return BooksError.ValidationError;
-        }
-
-        var command = new UpdateBookCommand(guidId, series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+        var command = new UpdateBookCommand(
+            guidId,
+            request.Series,
+            request.Title,
+            request.Isbn,
+            request.VolumeNumber,
+            request.ImageLink,
+            request.Rating,
+            request.Authors,
+            request.Publishers,
+            request.PublishDate,
+            request.NumberOfPages);
 
         return await updateBookHandler.Handle(command, cancellationToken);
     }

--- a/Web/Services/CreateBookRequest.cs
+++ b/Web/Services/CreateBookRequest.cs
@@ -1,0 +1,13 @@
+namespace Web.Services;
+
+public sealed record CreateBookRequest(
+    string Series,
+    string Title,
+    string Isbn,
+    int VolumeNumber = 1,
+    string ImageLink = "",
+    int Rating = 0,
+    string Authors = "",
+    string Publishers = "",
+    DateOnly? PublishDate = null,
+    int? NumberOfPages = null);

--- a/Web/Services/IBooksService.cs
+++ b/Web/Services/IBooksService.cs
@@ -9,15 +9,9 @@ namespace Web.Services;
 
 public interface IBooksService
 {
-    Task<Result<Book>> Create(string series, string title, string isbn);
-    Task<Result<Book>> Create(string series, string title, string isbn, int volumeNumber);
-    Task<Result<Book>> Create(string series, string title, string isbn, int volumeNumber, string imageLink, int rating, CancellationToken cancellationToken = default);
-    Task<Result<Book>> Create(string series, string title, string isbn, int volumeNumber, string imageLink, int rating,
-        string authors, string publishers, DateOnly? publishDate, int? numberOfPages, CancellationToken cancellationToken = default);
+    Task<Result<Book>> Create(CreateBookRequest request, CancellationToken cancellationToken = default);
     Task<Result<Book>> GetById(string? id);
-    Task<Result<Book>> Update(string? id, string series, string title, string isbn, int volumeNumber, string imageLink, int rating, CancellationToken cancellationToken = default);
-    Task<Result<Book>> Update(string? id, string series, string title, string isbn, int volumeNumber, string imageLink, int rating,
-        string authors, string publishers, DateOnly? publishDate, int? numberOfPages, CancellationToken cancellationToken = default);
+    Task<Result<Book>> Update(UpdateBookRequest request, CancellationToken cancellationToken = default);
     Task<Result<List<Book>>> GetAll();
     Task<Result> Delete(string? id, CancellationToken cancellationToken = default);
 }

--- a/Web/Services/IBooksService.cs
+++ b/Web/Services/IBooksService.cs
@@ -12,8 +12,12 @@ public interface IBooksService
     Task<Result<Book>> Create(string series, string title, string isbn);
     Task<Result<Book>> Create(string series, string title, string isbn, int volumeNumber);
     Task<Result<Book>> Create(string series, string title, string isbn, int volumeNumber, string imageLink, int rating, CancellationToken cancellationToken = default);
+    Task<Result<Book>> Create(string series, string title, string isbn, int volumeNumber, string imageLink, int rating,
+        string authors, string publishers, DateOnly? publishDate, int? numberOfPages, CancellationToken cancellationToken = default);
     Task<Result<Book>> GetById(string? id);
     Task<Result<Book>> Update(string? id, string series, string title, string isbn, int volumeNumber, string imageLink, int rating, CancellationToken cancellationToken = default);
+    Task<Result<Book>> Update(string? id, string series, string title, string isbn, int volumeNumber, string imageLink, int rating,
+        string authors, string publishers, DateOnly? publishDate, int? numberOfPages, CancellationToken cancellationToken = default);
     Task<Result<List<Book>>> GetAll();
     Task<Result> Delete(string? id, CancellationToken cancellationToken = default);
 }

--- a/Web/Services/UpdateBookRequest.cs
+++ b/Web/Services/UpdateBookRequest.cs
@@ -1,0 +1,14 @@
+namespace Web.Services;
+
+public sealed record UpdateBookRequest(
+    string? Id,
+    string Series,
+    string Title,
+    string Isbn,
+    int VolumeNumber,
+    string ImageLink,
+    int Rating,
+    string Authors = "",
+    string Publishers = "",
+    DateOnly? PublishDate = null,
+    int? NumberOfPages = null);

--- a/Web/Validators/BookUiDto.cs
+++ b/Web/Validators/BookUiDto.cs
@@ -24,6 +24,18 @@ public class BookUiDto : Entity<Guid>
     [Label("Rating")]
     public int Rating { get; set; } = 0;
 
+    [Label("Authors")]
+    public string Authors { get; set; } = string.Empty;
+
+    [Label("Publishers")]
+    public string Publishers { get; set; } = string.Empty;
+
+    [Label("Publish Date")]
+    public DateOnly? PublishDate { get; set; }
+
+    [Label("Number of Pages")]
+    public int? NumberOfPages { get; set; }
+
     public static BookUiDto Convert(Book book)
     {
         return new BookUiDto
@@ -35,6 +47,10 @@ public class BookUiDto : Entity<Guid>
             VolumeNumber = book.VolumeNumber,
             ImageLink = book.ImageLink,
             Rating = book.Rating,
+            Authors = book.Authors,
+            Publishers = book.Publishers,
+            PublishDate = book.PublishDate,
+            NumberOfPages = book.NumberOfPages,
             CreatedOnUtc = book.CreatedOnUtc,
             ModifiedOnUtc = book.ModifiedOnUtc
         };

--- a/Web/Validators/BookValidator.cs
+++ b/Web/Validators/BookValidator.cs
@@ -41,8 +41,7 @@ public class BookValidator : AbstractValidator<BookUiDto>
             .When(x => x.NumberOfPages.HasValue);
 
         RuleFor(x => x.PublishDate)
-            .LessThanOrEqualTo(DateOnly.FromDateTime(DateTime.UtcNow)).WithMessage("Publish date must not be in the future.")
-            .When(x => x.PublishDate.HasValue);
+            .Must(p => !p.HasValue || p.Value <= DateOnly.FromDateTime(DateTime.UtcNow)).WithMessage("Publish date must not be in the future.");
     }
 
     private static bool BeValidISBN(string isbn)

--- a/Web/Validators/BookValidator.cs
+++ b/Web/Validators/BookValidator.cs
@@ -1,4 +1,5 @@
 using Application.Helpers;
+using Domain.Books;
 using FluentValidation;
 
 namespace Web.Validators;
@@ -7,32 +8,41 @@ public class BookValidator : AbstractValidator<BookUiDto>
 {
     public BookValidator()
     {
-        const int maxTitleLength = 200;
-        const int maxSeriesLength = 200;
-        const int maxIsbnLength = 20;
-        const int maxImageLinkLength = 500;
-
         RuleFor(x => x.Title)
             .NotEmpty().WithMessage("Title is required.")
-            .MaximumLength(maxTitleLength).WithMessage($"Title must not exceed {maxTitleLength} characters.");
+            .MaximumLength(BookConstants.MaxTitleLength).WithMessage($"Title must not exceed {BookConstants.MaxTitleLength} characters.");
 
         RuleFor(x => x.ISBN)
             .NotEmpty().WithMessage("ISBN is required.")
-            .MaximumLength(maxIsbnLength).WithMessage($"ISBN must not exceed {maxIsbnLength} characters.")
+            .MaximumLength(BookConstants.MaxIsbnLength).WithMessage($"ISBN must not exceed {BookConstants.MaxIsbnLength} characters.")
             .Must(BeValidISBN).WithMessage("ISBN must be a valid 10 or 13 digit number.");
 
         RuleFor(x => x.Serie)
             .NotEmpty().WithMessage("Serie is required.")
-            .MaximumLength(maxSeriesLength).WithMessage($"Serie must not exceed {maxSeriesLength} characters.");
+            .MaximumLength(BookConstants.MaxSerieLength).WithMessage($"Serie must not exceed {BookConstants.MaxSerieLength} characters.");
 
         RuleFor(x => x.VolumeNumber)
             .GreaterThan(0).WithMessage("Volume number must be greater than 0.");
 
         RuleFor(x => x.ImageLink)
-            .MaximumLength(maxImageLinkLength).WithMessage($"Image link must not exceed {maxImageLinkLength} characters.");
+            .MaximumLength(BookConstants.MaxImageLinkLength).WithMessage($"Image link must not exceed {BookConstants.MaxImageLinkLength} characters.");
 
         RuleFor(x => x.Rating)
             .InclusiveBetween(0, 5).WithMessage("Rating must be between 0 and 5.");
+
+        RuleFor(x => x.Authors)
+            .MaximumLength(BookConstants.MaxAuthorsLength).WithMessage($"Authors must not exceed {BookConstants.MaxAuthorsLength} characters.");
+
+        RuleFor(x => x.Publishers)
+            .MaximumLength(BookConstants.MaxPublishersLength).WithMessage($"Publishers must not exceed {BookConstants.MaxPublishersLength} characters.");
+
+        RuleFor(x => x.NumberOfPages)
+            .GreaterThan(0).WithMessage("Number of pages must be greater than 0.")
+            .When(x => x.NumberOfPages.HasValue);
+
+        RuleFor(x => x.PublishDate)
+            .LessThanOrEqualTo(DateOnly.FromDateTime(DateTime.UtcNow)).WithMessage("Publish date must not be in the future.")
+            .When(x => x.PublishDate.HasValue);
     }
 
     private static bool BeValidISBN(string isbn)

--- a/Web/appsettings.json
+++ b/Web/appsettings.json
@@ -27,7 +27,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "NeonConnection": "Host=your-neon-host;Database=your-database;Username=your-username;Password=your-password",
+    "NeonConnection": "Host=ep-cold-sea-a9wk5hm4-pooler.gwc.azure.neon.tech;Database=mcm;Username=neondb_owner;Password=npg_q3d1zowuIPnO;SSL Mode=Require;Trust Server Certificate=true",
     "NeonConnectionUnitTests": "Host=your-neon-host;Database=your-database;Username=your-username;Password=your-password"
   },
   "Auth0": {

--- a/Web/appsettings.json
+++ b/Web/appsettings.json
@@ -27,7 +27,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "NeonConnection": "Host=ep-cold-sea-a9wk5hm4-pooler.gwc.azure.neon.tech;Database=mcm;Username=neondb_owner;Password=npg_q3d1zowuIPnO;SSL Mode=Require;Trust Server Certificate=true",
+    "NeonConnection": "Host=your-neon-host;Database=your-database;Username=your-username;Password=your-password",
     "NeonConnectionUnitTests": "Host=your-neon-host;Database=your-database;Username=your-username;Password=your-password"
   },
   "Auth0": {
@@ -38,9 +38,9 @@
     "RootPath": "/tmp"
   },
   "Cloudinary": {
-    "CloudName": "mcm-ndt",
-    "ApiKey": "339353142729877",
-    "ApiSecret": "E6GPtAlfFPcKFkiI93kZxdCTtLk",
-    "Folder": "covers"
+    "CloudName": "cloudname",
+    "ApiKey": "apikey",
+    "ApiSecret": "apisecret",
+    "Folder": "folder"
   }
 }

--- a/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -12,6 +12,10 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" />
     <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MockQueryable.NSubstitute" />
     <PackageReference Include="NSubstitute" />
@@ -29,10 +33,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Application\Application.csproj" />
     <ProjectReference Include="..\..\Persistence\Persistence.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="ComicInfoSearch\" />
   </ItemGroup>
 
 </Project>

--- a/tests/Application.UnitTests/Books/CreateBookCommandHandlerTests.cs
+++ b/tests/Application.UnitTests/Books/CreateBookCommandHandlerTests.cs
@@ -292,4 +292,346 @@ public class CreateBookCommandHandlerTests
         await _bookRepositoryMock.Received(1).GetByIsbnAsync(normalizedIsbn, cancellationToken);
         await _unitOfWorkMock.Received(1).SaveChangesAsync(cancellationToken);
     }
+
+    #region Metadata Fields Tests
+
+    [Fact]
+    public async Task Handle_Should_CreateBookWithAllMetadataFields()
+    {
+        // Arrange
+        const string authors = "Brian K. Vaughan, Fiona Staples";
+        const string publishers = "Image Comics";
+        var publishDate = new DateOnly(2012, 10, 10);
+        const int numberOfPages = 160;
+
+        var commandWithMetadata = new CreateBookCommand(
+            "Saga",
+            "Volume 1",
+            "978-1-60706-601-9",
+            1,
+            "https://example.com/saga.jpg",
+            5,
+            authors,
+            publishers,
+            publishDate,
+            numberOfPages
+        );
+
+        var normalizedIsbn = IsbnHelper.NormalizeIsbn(commandWithMetadata.ISBN);
+        _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>())
+            .Returns((Book?)null);
+
+        // Act
+        var result = await _handler.Handle(commandWithMetadata, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        Guard.Against.Null(result.Value);
+        result.Value.Authors.Should().Be(authors);
+        result.Value.Publishers.Should().Be(publishers);
+        result.Value.PublishDate.Should().Be(publishDate);
+        result.Value.NumberOfPages.Should().Be(numberOfPages);
+        _bookRepositoryMock.Received(1).Add(Arg.Any<Book>());
+        await _unitOfWorkMock.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_Should_CreateBookWithAuthorsAndPublishers()
+    {
+        // Arrange
+        const string authors = "Alan Moore, Dave Gibbons";
+        const string publishers = "DC Comics";
+
+        var command = new CreateBookCommand(
+            "Watchmen",
+            "Watchmen",
+            "978-1-4012-4525-2",
+            Authors: authors,
+            Publishers: publishers
+        );
+
+        var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
+        _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>())
+            .Returns((Book?)null);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        Guard.Against.Null(result.Value);
+        result.Value.Authors.Should().Be(authors);
+        result.Value.Publishers.Should().Be(publishers);
+        result.Value.PublishDate.Should().BeNull();
+        result.Value.NumberOfPages.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_Should_CreateBookWithPublishDate()
+    {
+        // Arrange
+        var publishDate = new DateOnly(2004, 10, 1);
+
+        var command = new CreateBookCommand(
+            "The Walking Dead",
+            "Days Gone Bye",
+            "978-1-58240-619-0",
+            PublishDate: publishDate
+        );
+
+        var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
+        _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>())
+            .Returns((Book?)null);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        Guard.Against.Null(result.Value);
+        result.Value.PublishDate.Should().Be(publishDate);
+        result.Value.Authors.Should().BeEmpty();
+        result.Value.Publishers.Should().BeEmpty();
+        result.Value.NumberOfPages.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_Should_CreateBookWithNumberOfPages()
+    {
+        // Arrange
+        const int numberOfPages = 128;
+
+        var command = new CreateBookCommand(
+            "Y: The Last Man",
+            "Unmanned",
+            "978-1-4012-1951-2",
+            NumberOfPages: numberOfPages
+        );
+
+        var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
+        _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>())
+            .Returns((Book?)null);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        Guard.Against.Null(result.Value);
+        result.Value.NumberOfPages.Should().Be(numberOfPages);
+        result.Value.Authors.Should().BeEmpty();
+        result.Value.Publishers.Should().BeEmpty();
+        result.Value.PublishDate.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_Should_CreateBookWithNullMetadata_WhenNotProvided()
+    {
+        // Arrange
+        var command = new CreateBookCommand(
+            "Fables",
+            "Volume 1",
+            "978-1-56389-942-3"
+        );
+
+        var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
+        _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>())
+            .Returns((Book?)null);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        Guard.Against.Null(result.Value);
+        result.Value.Authors.Should().BeEmpty();
+        result.Value.Publishers.Should().BeEmpty();
+        result.Value.PublishDate.Should().BeNull();
+        result.Value.NumberOfPages.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_Should_CreateBookWithEmptyAuthorsAndPublishers()
+    {
+        // Arrange
+        var command = new CreateBookCommand(
+            "Unknown Series",
+            "Unknown Title",
+            "978-3-16-148410-0",
+            Authors: "",
+            Publishers: ""
+        );
+
+        var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
+        _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>())
+            .Returns((Book?)null);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        Guard.Against.Null(result.Value);
+        result.Value.Authors.Should().BeEmpty();
+        result.Value.Publishers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_Should_CreateBookWithMultipleAuthors()
+    {
+        // Arrange
+        const string authors = "Stan Lee, Jack Kirby, Steve Ditko";
+        var command = new CreateBookCommand(
+            "Marvel",
+            "The Avengers",
+            "978-1-4012-4525-2",
+            Authors: authors
+        );
+
+        var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
+        _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>())
+            .Returns((Book?)null);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        Guard.Against.Null(result.Value);
+        result.Value.Authors.Should().Be(authors);
+    }
+
+    [Fact]
+    public async Task Handle_Should_CreateBookWithMultiplePublishers()
+    {
+        // Arrange
+        const string publishers = "Marvel Comics, DC Comics";
+        var command = new CreateBookCommand(
+            "Crossover",
+            "JLA/Avengers",
+            "978-1-4012-0331-3",
+            Publishers: publishers
+        );
+
+        var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
+        _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>())
+            .Returns((Book?)null);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        Guard.Against.Null(result.Value);
+        result.Value.Publishers.Should().Be(publishers);
+    }
+
+    [Fact]
+    public async Task Handle_Should_CreateBookWithHistoricalPublishDate()
+    {
+        // Arrange
+        var publishDate = new DateOnly(1962, 8, 1);
+        var command = new CreateBookCommand(
+            "Amazing Fantasy",
+            "Spider-Man's First Appearance",
+            "978-1-60706-601-9",
+            15,
+            "",
+            0,
+            "Stan Lee, Steve Ditko",
+            "Marvel Comics",
+            publishDate,
+            11
+        );
+
+        var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
+        _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>())
+            .Returns((Book?)null);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        Guard.Against.Null(result.Value);
+        result.Value.PublishDate.Should().Be(publishDate);
+        result.Value.NumberOfPages.Should().Be(11);
+    }
+
+    [Fact]
+    public async Task Handle_Should_CreateBookWithLargeNumberOfPages()
+    {
+        // Arrange
+        const int numberOfPages = 416;
+        var command = new CreateBookCommand(
+            "Watchmen",
+            "Watchmen",
+            "978-0-930289-23-2",
+            1,
+            "",
+            0,
+            "Alan Moore",
+            "DC Comics",
+            new DateOnly(1987, 9, 1),
+            numberOfPages
+        );
+
+        var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
+        _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>())
+            .Returns((Book?)null);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        Guard.Against.Null(result.Value);
+        result.Value.NumberOfPages.Should().Be(numberOfPages);
+    }
+
+    [Fact]
+    public async Task Handle_Should_PassAllMetadataToBookCreate()
+    {
+        // Arrange
+        const string serie = "Saga";
+        const string title = "Volume 1";
+        const string isbn = "978-1-60706-601-9";
+        const int volumeNumber = 1;
+        const string imageLink = "https://example.com/saga.jpg";
+        const int rating = 5;
+        const string authors = "Brian K. Vaughan, Fiona Staples";
+        const string publishers = "Image Comics";
+        var publishDate = new DateOnly(2012, 10, 10);
+        const int numberOfPages = 160;
+
+        var command = new CreateBookCommand(
+            serie, title, isbn, volumeNumber, imageLink, rating,
+            authors, publishers, publishDate, numberOfPages
+        );
+
+        var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
+        _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>())
+            .Returns((Book?)null);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        Guard.Against.Null(result.Value);
+        result.Value.Serie.Should().Be(serie);
+        result.Value.Title.Should().Be(title);
+        result.Value.ISBN.Should().Be(normalizedIsbn);
+        result.Value.VolumeNumber.Should().Be(volumeNumber);
+        result.Value.ImageLink.Should().Be(imageLink);
+        result.Value.Rating.Should().Be(rating);
+        result.Value.Authors.Should().Be(authors);
+        result.Value.Publishers.Should().Be(publishers);
+        result.Value.PublishDate.Should().Be(publishDate);
+        result.Value.NumberOfPages.Should().Be(numberOfPages);
+        result.Value.ReadingDates.Should().HaveCount(1); // Rating > 0, so reading date is added
+    }
+
+    #endregion
 }
+

--- a/tests/Application.UnitTests/Books/UpdateBookCommandHandlerTests.cs
+++ b/tests/Application.UnitTests/Books/UpdateBookCommandHandlerTests.cs
@@ -60,7 +60,7 @@ public class UpdateBookCommandHandlerTests
         result.IsSuccess.Should().BeTrue();
         result.Value.Serie.Should().Be(s_validCommand.Serie);
         result.Value.Title.Should().Be(s_validCommand.Title);
-        result.Value.ISBN.Should().Be(s_validCommand.ISBN);
+        result.Value.ISBN.Should().Be("9780306406157");
         result.Value.VolumeNumber.Should().Be(s_validCommand.VolumeNumber);
         result.Value.ImageLink.Should().Be(s_validCommand.ImageLink);
         _bookRepositoryMock.Received(1).Update(Arg.Any<Book>());
@@ -260,7 +260,7 @@ public class UpdateBookCommandHandlerTests
         result.IsSuccess.Should().BeTrue();
         result.Value.Serie.Should().Be("Updated Serie");
         result.Value.Title.Should().Be("Updated Title");
-        result.Value.ISBN.Should().Be("978-0-306-40615-7");
+        result.Value.ISBN.Should().Be("9780306406157");
         result.Value.VolumeNumber.Should().Be(2);
         result.Value.ImageLink.Should().Be("https://example.com/updated.jpg");
     }
@@ -312,7 +312,7 @@ public class UpdateBookCommandHandlerTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         Guard.Against.Null(result.Value);
-        result.Value.ISBN.Should().Be("0-306-40615-2");
+        result.Value.ISBN.Should().Be("0306406152");
         _bookRepositoryMock.Received(1).Update(Arg.Any<Book>());
         await _unitOfWorkMock.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
     }
@@ -332,7 +332,7 @@ public class UpdateBookCommandHandlerTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         Guard.Against.Null(result.Value);
-        result.Value.ISBN.Should().Be("978-0-306-40615-7");
+        result.Value.ISBN.Should().Be("9780306406157");
         _bookRepositoryMock.Received(1).Update(Arg.Any<Book>());
         await _unitOfWorkMock.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
     }

--- a/tests/Application.UnitTests/ComicInfoSearch/CloudinaryServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/CloudinaryServiceTests.cs
@@ -1,4 +1,4 @@
-using Application.ComicInfoSearch;
+using Application.Interfaces;
 
 namespace Application.UnitTests.ComicInfoSearch;
 

--- a/tests/Application.UnitTests/ComicInfoSearch/ComicSearchResultTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/ComicSearchResultTests.cs
@@ -1,4 +1,4 @@
-using Application.ComicInfoSearch;
+using Application.Interfaces;
 
 
 namespace Application.UnitTests.ComicInfoSearch;

--- a/tests/Application.UnitTests/ComicInfoSearch/ComicSearchResultTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/ComicSearchResultTests.cs
@@ -1,0 +1,310 @@
+using Application.ComicInfoSearch;
+
+
+namespace Application.UnitTests.ComicInfoSearch;
+
+public sealed class ComicSearchResultTests
+{
+    #region Constructor Tests
+
+    [Fact]
+    public void Constructor_ShouldInitializeWithAllProperties()
+    {
+        // Arrange
+        const string title = "The Amazing Spider-Man";
+        const string serie = "Spider-Man";
+        const string isbn = "9781234567890";
+        const int volumeNumber = 1;
+        const string imageUrl = "https://example.com/image.jpg";
+        const string authors = "Stan Lee, Steve Ditko";
+        const string publishers = "Marvel Comics";
+        var publishDate = new DateOnly(2024, 1, 15);
+        const int numberOfPages = 120;
+        const bool found = true;
+
+        // Act
+        var result = new ComicSearchResult(
+            title,
+            serie,
+            isbn,
+            volumeNumber,
+            imageUrl,
+            authors,
+            publishers,
+            publishDate,
+            numberOfPages,
+            found);
+
+        // Assert
+        result.Title.Should().Be(title);
+        result.Serie.Should().Be(serie);
+        result.Isbn.Should().Be(isbn);
+        result.VolumeNumber.Should().Be(volumeNumber);
+        result.ImageUrl.Should().Be(imageUrl);
+        result.Authors.Should().Be(authors);
+        result.Publishers.Should().Be(publishers);
+        result.PublishDate.Should().Be(publishDate);
+        result.NumberOfPages.Should().Be(numberOfPages);
+        result.Found.Should().Be(found);
+    }
+
+    [Fact]
+    public void Constructor_ShouldAcceptNullableProperties_WhenNull()
+    {
+        // Arrange
+        const string title = "Unknown Comic";
+        const string serie = "Unknown Series";
+        const string isbn = "0000000000000";
+        const int volumeNumber = 0;
+        const string imageUrl = "";
+        const string authors = "";
+        const string publishers = "";
+        const bool found = false;
+
+        // Act
+        var result = new ComicSearchResult(
+            title,
+            serie,
+            isbn,
+            volumeNumber,
+            imageUrl,
+            authors,
+            publishers,
+            null,
+            null,
+            found);
+
+        // Assert
+        result.Title.Should().Be(title);
+        result.Serie.Should().Be(serie);
+        result.Isbn.Should().Be(isbn);
+        result.VolumeNumber.Should().Be(volumeNumber);
+        result.ImageUrl.Should().Be(imageUrl);
+        result.Authors.Should().Be(authors);
+        result.Publishers.Should().Be(publishers);
+        result.PublishDate.Should().BeNull();
+        result.NumberOfPages.Should().BeNull();
+        result.Found.Should().Be(found);
+    }
+
+    #endregion
+
+    #region Equality Tests
+
+    [Fact]
+    public void Equals_ShouldReturnTrue_WhenAllPropertiesMatch()
+    {
+        // Arrange
+        var publishDate = new DateOnly(2024, 1, 15);
+        var result1 = new ComicSearchResult(
+            "Title",
+            "Serie",
+            "1234567890",
+            1,
+            "https://example.com/image.jpg",
+            "Author",
+            "Publisher",
+            publishDate,
+            100,
+            true);
+
+        var result2 = new ComicSearchResult(
+            "Title",
+            "Serie",
+            "1234567890",
+            1,
+            "https://example.com/image.jpg",
+            "Author",
+            "Publisher",
+            publishDate,
+            100,
+            true);
+
+        // Act & Assert
+        result1.Should().Be(result2);
+        (result1 == result2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_ShouldReturnFalse_WhenTitleDiffers()
+    {
+        // Arrange
+        var result1 = new ComicSearchResult("Title1", "Serie", "1234", 1, "", "", "", null, null, true);
+        var result2 = new ComicSearchResult("Title2", "Serie", "1234", 1, "", "", "", null, null, true);
+
+        // Act & Assert
+        result1.Should().NotBe(result2);
+        (result1 != result2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_ShouldReturnFalse_WhenIsbnDiffers()
+    {
+        // Arrange
+        var result1 = new ComicSearchResult("Title", "Serie", "1234567890", 1, "", "", "", null, null, true);
+        var result2 = new ComicSearchResult("Title", "Serie", "0987654321", 1, "", "", "", null, null, true);
+
+        // Act & Assert
+        result1.Should().NotBe(result2);
+    }
+
+    [Fact]
+    public void Equals_ShouldReturnFalse_WhenFoundDiffers()
+    {
+        // Arrange
+        var result1 = new ComicSearchResult("Title", "Serie", "1234", 1, "", "", "", null, null, true);
+        var result2 = new ComicSearchResult("Title", "Serie", "1234", 1, "", "", "", null, null, false);
+
+        // Act & Assert
+        result1.Should().NotBe(result2);
+    }
+
+    [Fact]
+    public void GetHashCode_ShouldBeSame_WhenObjectsAreEqual()
+    {
+        // Arrange
+        var publishDate = new DateOnly(2024, 1, 15);
+        var result1 = new ComicSearchResult("Title", "Serie", "1234", 1, "url", "Author", "Publisher", publishDate, 100, true);
+        var result2 = new ComicSearchResult("Title", "Serie", "1234", 1, "url", "Author", "Publisher", publishDate, 100, true);
+
+        // Act & Assert
+        result1.GetHashCode().Should().Be(result2.GetHashCode());
+    }
+
+    #endregion
+
+    #region With Expression Tests
+
+    [Fact]
+    public void With_ShouldCreateNewInstance_WhenModifyingTitle()
+    {
+        // Arrange
+        var original = new ComicSearchResult("Original Title", "Serie", "1234", 1, "", "", "", null, null, true);
+
+        // Act
+        var modified = original with { Title = "New Title" };
+
+        // Assert
+        modified.Title.Should().Be("New Title");
+        modified.Serie.Should().Be(original.Serie);
+        modified.Isbn.Should().Be(original.Isbn);
+        original.Title.Should().Be("Original Title");
+    }
+
+    [Fact]
+    public void With_ShouldCreateNewInstance_WhenModifyingFound()
+    {
+        // Arrange
+        var original = new ComicSearchResult("Title", "Serie", "1234", 1, "", "", "", null, null, false);
+
+        // Act
+        var modified = original with { Found = true };
+
+        // Assert
+        modified.Found.Should().BeTrue();
+        original.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public void With_ShouldCreateNewInstance_WhenModifyingNullableProperty()
+    {
+        // Arrange
+        var original = new ComicSearchResult("Title", "Serie", "1234", 1, "", "", "", null, null, true);
+        var newDate = new DateOnly(2024, 12, 25);
+
+        // Act
+        var modified = original with { PublishDate = newDate };
+
+        // Assert
+        modified.PublishDate.Should().Be(newDate);
+        original.PublishDate.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Deconstruction Tests
+
+    [Fact]
+    public void Deconstruct_ShouldExtractAllProperties()
+    {
+        // Arrange
+        var publishDate = new DateOnly(2024, 1, 15);
+        var result = new ComicSearchResult(
+            "Title",
+            "Serie",
+            "1234567890",
+            5,
+            "https://example.com/image.jpg",
+            "Author",
+            "Publisher",
+            publishDate,
+            150,
+            true);
+
+        // Act
+        var (title, serie, isbn, volumeNumber, imageUrl, authors, publishers, pubDate, pages, found) = result;
+
+        // Assert
+        title.Should().Be("Title");
+        serie.Should().Be("Serie");
+        isbn.Should().Be("1234567890");
+        volumeNumber.Should().Be(5);
+        imageUrl.Should().Be("https://example.com/image.jpg");
+        authors.Should().Be("Author");
+        publishers.Should().Be("Publisher");
+        pubDate.Should().Be(publishDate);
+        pages.Should().Be(150);
+        found.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Fact]
+    public void Constructor_ShouldAcceptEmptyStrings()
+    {
+        // Act
+        var result = new ComicSearchResult(
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            0,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            null,
+            null,
+            false);
+
+        // Assert
+        result.Title.Should().Be(string.Empty);
+        result.Serie.Should().Be(string.Empty);
+        result.Isbn.Should().Be(string.Empty);
+        result.ImageUrl.Should().Be(string.Empty);
+        result.Authors.Should().Be(string.Empty);
+        result.Publishers.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void Constructor_ShouldAcceptNegativeVolumeNumber()
+    {
+        // Act
+        var result = new ComicSearchResult("Title", "Serie", "1234", -1, "", "", "", null, null, false);
+
+        // Assert
+        result.VolumeNumber.Should().Be(-1);
+    }
+
+    [Fact]
+    public void Constructor_ShouldAcceptZeroNumberOfPages()
+    {
+        // Act
+        var result = new ComicSearchResult("Title", "Serie", "1234", 1, "", "", "", null, 0, true);
+
+        // Assert
+        result.NumberOfPages.Should().Be(0);
+    }
+
+    #endregion
+}

--- a/tests/Application.UnitTests/ComicInfoSearch/ComicSearchServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/ComicSearchServiceTests.cs
@@ -1,4 +1,5 @@
 using Application.ComicInfoSearch;
+using Application.Interfaces;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;

--- a/tests/Application.UnitTests/ComicInfoSearch/ComicSearchServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/ComicSearchServiceTests.cs
@@ -797,6 +797,27 @@ public sealed class ComicSearchServiceTests
         result.Serie.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldReturnNotFound_WhenTokenIsCancelledByCallerBeforeCall()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync(); // Cancel the token before the call
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn, cts.Token);
+
+        // Assert
+        result.Found.Should().BeFalse();
+        result.Isbn.Should().Be(isbn);
+        result.Title.Should().BeEmpty();
+        result.Serie.Should().BeEmpty();
+    }
+
     #endregion
 
     #region Multiple Authors and Publishers Tests

--- a/tests/Application.UnitTests/ComicInfoSearch/ComicSearchServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/ComicSearchServiceTests.cs
@@ -1,0 +1,620 @@
+using Application.ComicInfoSearch;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+
+namespace Application.UnitTests.ComicInfoSearch;
+
+public sealed class ComicSearchServiceTests
+{
+    private static readonly string[] EmptyStringArray = [];
+    private static readonly string[] SingleAuthorArray = ["Author"];
+    private static readonly string[] SinglePublisherArray = ["Publisher"];
+
+    private readonly IOpenLibraryService _openLibraryService;
+    private readonly ICloudinaryService _cloudinaryService;
+    private readonly IOptions<CloudinarySettings> _cloudinarySettings;
+    private readonly ComicSearchService _sut;
+
+    public ComicSearchServiceTests()
+    {
+        _openLibraryService = Substitute.For<IOpenLibraryService>();
+        _cloudinaryService = Substitute.For<ICloudinaryService>();
+        _cloudinarySettings = Options.Create(new CloudinarySettings
+        {
+            CloudName = "test-cloud",
+            ApiKey = "test-key",
+            ApiSecret = "test-secret",
+            Folder = "test-covers"
+        });
+        _sut = new ComicSearchService(_openLibraryService, _cloudinaryService, _cloudinarySettings);
+    }
+
+    #region SearchByIsbnAsync Tests
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldReturnNotFound_WhenOpenLibraryReturnsNotFound()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: string.Empty,
+            Subtitle: null,
+            Authors: EmptyStringArray,
+            Publishers: EmptyStringArray,
+            PublishDate: null,
+            NumberOfPages: null,
+            CoverUrl: null,
+            Found: false);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.Found.Should().BeFalse();
+        result.Isbn.Should().Be(isbn);
+        result.Title.Should().BeEmpty();
+        result.Serie.Should().BeEmpty();
+        result.VolumeNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldReturnSuccess_WhenOpenLibraryReturnsData()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        const string title = "Soda, tome 1";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: title,
+            Subtitle: null,
+            Authors: ["Philippe Tome", "Luc Wartholz"],
+            Publishers: ["Dupuis"],
+            PublishDate: "1987",
+            NumberOfPages: 48,
+            CoverUrl: new Uri("https://covers.openlibrary.org/b/id/12345-L.jpg"),
+            Found: true);
+
+        var cloudinaryResult = new CloudinaryUploadResult(
+            Url: new Uri("https://res.cloudinary.com/test/image/upload/v1/test-covers/9781234567890.jpg"),
+            PublicId: "test-covers/9781234567890",
+            Success: true,
+            Error: null);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+        _cloudinaryService.UploadImageFromUrlAsync(
+                Arg.Any<Uri>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(cloudinaryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.Found.Should().BeTrue();
+        result.Isbn.Should().Be(isbn);
+        result.Title.Should().Be(title);
+        result.Serie.Should().Be("Soda");
+        result.VolumeNumber.Should().Be(1);
+        result.Authors.Should().Be("Philippe Tome, Luc Wartholz");
+        result.Publishers.Should().Be("Dupuis");
+        result.NumberOfPages.Should().Be(48);
+        result.ImageUrl.Should().Be("https://res.cloudinary.com/test/image/upload/v1/test-covers/9781234567890.jpg");
+        result.PublishDate.Should().Be(new DateOnly(1987, 1, 1));
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldUseSubtitleAsTitle_WhenSubtitleIsProvided()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        const string title = "The Amazing Spider-Man";
+        const string subtitle = "Volume 1: Coming Home";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: title,
+            Subtitle: subtitle,
+            Authors: ["Stan Lee"],
+            Publishers: ["Marvel"],
+            PublishDate: "2001-01-01",
+            NumberOfPages: 120,
+            CoverUrl: null,
+            Found: true);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.Title.Should().Be(subtitle);
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldUploadCoverToCloudinary_WhenCoverUrlIsProvided()
+    {
+        // Arrange
+        const string isbn = "978-1234-5678-90";
+        var coverUrl = new Uri("https://covers.openlibrary.org/b/id/12345-L.jpg");
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: "Test Comic",
+            Subtitle: null,
+            Authors: SingleAuthorArray,
+            Publishers: SinglePublisherArray,
+            PublishDate: "2024",
+            NumberOfPages: 100,
+            CoverUrl: coverUrl,
+            Found: true);
+
+        var cloudinaryResult = new CloudinaryUploadResult(
+            Url: new Uri("https://res.cloudinary.com/test/uploaded.jpg"),
+            PublicId: "test-id",
+            Success: true,
+            Error: null);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+        _cloudinaryService.UploadImageFromUrlAsync(
+                coverUrl,
+                "test-covers",
+                "9781234567890",
+                Arg.Any<CancellationToken>())
+            .Returns(cloudinaryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.ImageUrl.Should().Be("https://res.cloudinary.com/test/uploaded.jpg");
+        await _cloudinaryService.Received(1).UploadImageFromUrlAsync(
+            coverUrl,
+            "test-covers",
+            "9781234567890",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldUseOriginalUrl_WhenCloudinaryUploadFails()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        var coverUrl = new Uri("https://covers.openlibrary.org/b/id/12345-L.jpg");
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: "Test Comic",
+            Subtitle: null,
+            Authors: SingleAuthorArray,
+            Publishers: SinglePublisherArray,
+            PublishDate: "2024",
+            NumberOfPages: 100,
+            CoverUrl: coverUrl,
+            Found: true);
+
+        var cloudinaryResult = new CloudinaryUploadResult(
+            Url: null,
+            PublicId: null,
+            Success: false,
+            Error: "Upload failed");
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+        _cloudinaryService.UploadImageFromUrlAsync(
+                Arg.Any<Uri>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(cloudinaryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.ImageUrl.Should().Be(coverUrl.ToString());
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldReturnEmptyImageUrl_WhenNoCoverUrlProvided()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: "Test Comic",
+            Subtitle: null,
+            Authors: SingleAuthorArray,
+            Publishers: SinglePublisherArray,
+            PublishDate: "2024",
+            NumberOfPages: 100,
+            CoverUrl: null,
+            Found: true);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.ImageUrl.Should().BeEmpty();
+        await _cloudinaryService.DidNotReceive().UploadImageFromUrlAsync(
+            Arg.Any<Uri>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldReturnNotFound_WhenHttpRequestExceptionIsThrown()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Network error"));
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.Found.Should().BeFalse();
+        result.Isbn.Should().Be(isbn);
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldReturnNotFound_WhenInvalidOperationExceptionIsThrown()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Invalid operation"));
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.Found.Should().BeFalse();
+        result.Isbn.Should().Be(isbn);
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldReturnNotFound_WhenTimeoutOccurs()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TaskCanceledException("Request timeout"));
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.Found.Should().BeFalse();
+        result.Isbn.Should().Be(isbn);
+    }
+
+    #endregion
+
+    #region ParseVolumeAndSerie Tests
+
+    [Theory]
+    [InlineData("Soda, tome 1", "Soda", 1)]
+    [InlineData("Soda, tome 12", "Soda", 12)]
+    [InlineData("Tintin - tome 3", "Tintin", 3)]
+    [InlineData("Asterix - tome 24", "Asterix", 24)]
+    [InlineData("Spider-Man, vol. 5", "Spider-Man", 5)]
+    [InlineData("Batman, vol 10", "Batman", 10)]
+    [InlineData("Superman - vol. 2", "Superman", 2)]
+    [InlineData("X-Men vol. 1", "X-Men", 1)]
+    [InlineData("Avengers vol 3", "Avengers", 3)]
+    [InlineData("Naruto #15", "Naruto", 15)]
+    public async Task SearchByIsbnAsync_ShouldParseVolumeAndSerie_WithVariousFormats(
+        string title,
+        string expectedSerie,
+        int expectedVolume)
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: title,
+            Subtitle: null,
+            Authors: SingleAuthorArray,
+            Publishers: SinglePublisherArray,
+            PublishDate: "2024",
+            NumberOfPages: 100,
+            CoverUrl: null,
+            Found: true);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.Serie.Should().Be(expectedSerie);
+        result.VolumeNumber.Should().Be(expectedVolume);
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldUseFullTitleAsSerie_WhenNoVolumePatternMatches()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        const string title = "The Watchmen";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: title,
+            Subtitle: null,
+            Authors: ["Alan Moore"],
+            Publishers: ["DC Comics"],
+            PublishDate: "1987",
+            NumberOfPages: 416,
+            CoverUrl: null,
+            Found: true);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.Serie.Should().Be(title);
+        result.VolumeNumber.Should().Be(1);
+    }
+
+    #endregion
+
+    #region ParsePublishDate Tests
+
+    [Theory]
+    [InlineData("September 16, 1987", 1987, 9, 16)]
+    [InlineData("Sep 16, 1987", 1987, 9, 16)]
+    [InlineData("1987-09-16", 1987, 9, 16)]
+    [InlineData("1987/09/16", 1987, 9, 16)]
+    [InlineData("16/09/1987", 1987, 9, 16)]
+    [InlineData("September 1987", 1987, 9, 1)]
+    [InlineData("Sep 1987", 1987, 9, 1)]
+    [InlineData("1987", 1987, 1, 1)]
+    public async Task SearchByIsbnAsync_ShouldParsePublishDate_WithVariousFormats(
+        string publishDate,
+        int expectedYear,
+        int expectedMonth,
+        int expectedDay)
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: "Test Comic",
+            Subtitle: null,
+            Authors: SingleAuthorArray,
+            Publishers: SinglePublisherArray,
+            PublishDate: publishDate,
+            NumberOfPages: 100,
+            CoverUrl: null,
+            Found: true);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.PublishDate.Should().Be(new DateOnly(expectedYear, expectedMonth, expectedDay));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SearchByIsbnAsync_ShouldReturnNullPublishDate_WhenDateStringIsNullOrEmpty(string? publishDate)
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: "Test Comic",
+            Subtitle: null,
+            Authors: SingleAuthorArray,
+            Publishers: SinglePublisherArray,
+            PublishDate: publishDate,
+            NumberOfPages: 100,
+            CoverUrl: null,
+            Found: true);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.PublishDate.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldReturnNullPublishDate_WhenDateStringIsInvalid()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: "Test Comic",
+            Subtitle: null,
+            Authors: SingleAuthorArray,
+            Publishers: SinglePublisherArray,
+            PublishDate: "invalid-date",
+            NumberOfPages: 100,
+            CoverUrl: null,
+            Found: true);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.PublishDate.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Multiple Authors and Publishers Tests
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldCombineMultipleAuthors_AsCommaSeparatedString()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: "Test Comic",
+            Subtitle: null,
+            Authors: ["Stan Lee", "Jack Kirby", "Steve Ditko"],
+            Publishers: SinglePublisherArray,
+            PublishDate: "2024",
+            NumberOfPages: 100,
+            CoverUrl: null,
+            Found: true);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.Authors.Should().Be("Stan Lee, Jack Kirby, Steve Ditko");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldCombineMultiplePublishers_AsCommaSeparatedString()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: "Test Comic",
+            Subtitle: null,
+            Authors: SingleAuthorArray,
+            Publishers: ["Marvel Comics", "DC Comics", "Image Comics"],
+            PublishDate: "2024",
+            NumberOfPages: 100,
+            CoverUrl: null,
+            Found: true);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.Publishers.Should().Be("Marvel Comics, DC Comics, Image Comics");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldHandleEmptyAuthorsAndPublishers()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: "Test Comic",
+            Subtitle: null,
+            Authors: EmptyStringArray,
+            Publishers: EmptyStringArray,
+            PublishDate: "2024",
+            NumberOfPages: 100,
+            CoverUrl: null,
+            Found: true);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.Authors.Should().BeEmpty();
+        result.Publishers.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region CancellationToken Tests
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldPassCancellationToken_ToOpenLibraryService()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        using var cts = new CancellationTokenSource();
+        var cancellationToken = cts.Token;
+
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: "Test",
+            Subtitle: null,
+            Authors: EmptyStringArray,
+            Publishers: EmptyStringArray,
+            PublishDate: null,
+            NumberOfPages: null,
+            CoverUrl: null,
+            Found: true);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, cancellationToken)
+            .Returns(openLibraryResult);
+
+        // Act
+        await _sut.SearchByIsbnAsync(isbn, cancellationToken);
+
+        // Assert
+        await _openLibraryService.Received(1).SearchByIsbnAsync(isbn, cancellationToken);
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldPassCancellationToken_ToCloudinaryService()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        using var cts = new CancellationTokenSource();
+        var cancellationToken = cts.Token;
+        var coverUrl = new Uri("https://covers.openlibrary.org/b/id/12345-L.jpg");
+
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: "Test",
+            Subtitle: null,
+            Authors: EmptyStringArray,
+            Publishers: EmptyStringArray,
+            PublishDate: null,
+            NumberOfPages: null,
+            CoverUrl: coverUrl,
+            Found: true);
+
+        var cloudinaryResult = new CloudinaryUploadResult(
+            Url: new Uri("https://res.cloudinary.com/test/uploaded.jpg"),
+            PublicId: "test-id",
+            Success: true,
+            Error: null);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, cancellationToken)
+            .Returns(openLibraryResult);
+        _cloudinaryService.UploadImageFromUrlAsync(
+                Arg.Any<Uri>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                cancellationToken)
+            .Returns(cloudinaryResult);
+
+        // Act
+        await _sut.SearchByIsbnAsync(isbn, cancellationToken);
+
+        // Assert
+        await _cloudinaryService.Received(1).UploadImageFromUrlAsync(
+            coverUrl,
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            cancellationToken);
+    }
+
+    #endregion
+}

--- a/tests/Architecture.Tests/Architecture.Tests.csproj
+++ b/tests/Architecture.Tests/Architecture.Tests.csproj
@@ -11,6 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NetArchTest.Rules" />
     <PackageReference Include="xunit" />

--- a/tests/Base.Integration.Tests/IntegrationTestWebAppFactory.cs
+++ b/tests/Base.Integration.Tests/IntegrationTestWebAppFactory.cs
@@ -6,6 +6,9 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Npgsql;
 using Persistence;
 using Persistence.LocalStorage;
 
@@ -48,22 +51,22 @@ public sealed class IntegrationTestWebAppFactory : WebApplicationFactory<Program
                 services.Remove(descriptor);
             }
 
+            // Add connection timeout to prevent hanging tests
+            // Increased timeout for Neon database wake-up (free tier auto-pauses after inactivity)
+            var connectionStringBuilder = new NpgsqlConnectionStringBuilder(_connectionString)
+            {
+                Timeout = 60, // 60 seconds connection timeout (allows time for Neon to wake up)
+                CommandTimeout = 60 // 60 seconds command timeout
+            };
+
             services.AddDbContext<ApplicationDbContext>(options =>
             options
-                .UseNpgsql(_connectionString, npgsqlOptions =>
+                .UseNpgsql(connectionStringBuilder.ToString(), npgsqlOptions =>
                     npgsqlOptions.MigrationsAssembly("Persistence")
                 )
                 .EnableDetailedErrors(true)
+                .EnableSensitiveDataLogging(false)
             );
-        });
-
-        builder.ConfigureTestServices(services =>
-        {
-            var provider = services.BuildServiceProvider();
-            using var scope = provider.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            db.Database.EnsureDeleted();
-            db.Database.Migrate();
         });
 
         // Reconfigure the service to use LocalStorage with a new root path as Temp directory
@@ -81,8 +84,73 @@ public sealed class IntegrationTestWebAppFactory : WebApplicationFactory<Program
         });
     }
 
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        var host = base.CreateHost(builder);
+        
+        // Run migrations after host is created to avoid deadlocks
+        using (var scope = host.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var logger = scope.ServiceProvider.GetRequiredService<ILogger<IntegrationTestWebAppFactory>>();
+            
+            try
+            {
+                logger.LogInformation("Running database migrations for: {Host}", GetHostFromConnectionString(_connectionString));
+                logger.LogInformation("Note: Neon free tier databases may take 10-30 seconds to wake from sleep...");
+                
+                db.Database.Migrate();
+                
+                logger.LogInformation("Database migrations completed successfully.");
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to run database migrations");
+                throw new InvalidOperationException(
+                    $"Cannot initialize test database: {ex.Message}\n" +
+                    $"Connection: {MaskPassword(_connectionString)}\n" +
+                    $"Ensure the database server is running and accessible.\n" +
+                    $"Set ConnectionStrings__NeonConnectionUnitTests environment variable to use a local database.",
+                    ex
+                );
+            }
+        }
+        
+        return host;
+    }
+
     public new void Dispose()
     {
         base.Dispose();
+    }
+
+    private static string MaskPassword(string connectionString)
+    {
+        try
+        {
+            var builder = new NpgsqlConnectionStringBuilder(connectionString);
+            if (!string.IsNullOrEmpty(builder.Password))
+            {
+                builder.Password = "***MASKED***";
+            }
+            return builder.ToString();
+        }
+        catch
+        {
+            return "***CONNECTION_STRING_PARSE_ERROR***";
+        }
+    }
+
+    private static string GetHostFromConnectionString(string connectionString)
+    {
+        try
+        {
+            var builder = new NpgsqlConnectionStringBuilder(connectionString);
+            return builder.Host ?? "unknown";
+        }
+        catch
+        {
+            return "unknown";
+        }
     }
 }

--- a/tests/Base.Integration.Tests/IntegrationTestWebAppFactory.cs
+++ b/tests/Base.Integration.Tests/IntegrationTestWebAppFactory.cs
@@ -97,10 +97,7 @@ public sealed class IntegrationTestWebAppFactory : WebApplicationFactory<Program
                 var logger = scope.ServiceProvider.GetRequiredService<ILogger<IntegrationTestWebAppFactory>>();
                 
                 try
-                {
-                    logger.LogInformation("Running database migrations for: {Host}", GetHostFromConnectionString(_connectionString));
-                    logger.LogInformation("Note: Neon free tier databases may take 10-30 seconds to wake from sleep...");
-                    
+                {                    
                     db.Database.Migrate();
                     
                     logger.LogInformation("Database migrations completed successfully.");

--- a/tests/Base.Integration.Tests/IntegrationTestWebAppFactory.cs
+++ b/tests/Base.Integration.Tests/IntegrationTestWebAppFactory.cs
@@ -135,7 +135,7 @@ public sealed class IntegrationTestWebAppFactory : WebApplicationFactory<Program
             }
             return builder.ToString();
         }
-        catch
+        catch (ArgumentException)
         {
             return "***CONNECTION_STRING_PARSE_ERROR***";
         }
@@ -148,9 +148,10 @@ public sealed class IntegrationTestWebAppFactory : WebApplicationFactory<Program
             var builder = new NpgsqlConnectionStringBuilder(connectionString);
             return builder.Host ?? "unknown";
         }
-        catch
+        catch (ArgumentException)
         {
             return "unknown";
         }
     }
 }
+

--- a/tests/Base.Integration.Tests/IntegrationTestWebAppFactory.cs
+++ b/tests/Base.Integration.Tests/IntegrationTestWebAppFactory.cs
@@ -62,6 +62,7 @@ public sealed class IntegrationTestWebAppFactory : WebApplicationFactory<Program
             var provider = services.BuildServiceProvider();
             using var scope = provider.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            db.Database.EnsureDeleted();
             db.Database.Migrate();
         });
 

--- a/tests/Domain.UnitTests/Books/BookTests.cs
+++ b/tests/Domain.UnitTests/Books/BookTests.cs
@@ -93,6 +93,122 @@ public class BookTests
     }
 
     [Fact]
+    public void Create_Should_CreateBookWithAllMetadata()
+    {
+        // Arrange
+        const string series = "Saga";
+        const string title = "Chapter One";
+        const string isbn = "9781607066019";
+        const int volumeNumber = 1;
+        const string imageLink = "https://example.com/saga.jpg";
+        const int rating = 5;
+        const string authors = "Brian K. Vaughan, Fiona Staples";
+        const string publishers = "Image Comics";
+        var publishDate = new DateOnly(2012, 10, 10);
+        const int numberOfPages = 160;
+
+        // Act
+        var book = Book.Create(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+
+        // Assert
+        book.Should().NotBeNull();
+        book.Id.Should().NotBe(Guid.Empty);
+        book.Serie.Should().Be(series);
+        book.Title.Should().Be(title);
+        book.ISBN.Should().Be(isbn);
+        book.VolumeNumber.Should().Be(volumeNumber);
+        book.ImageLink.Should().Be(imageLink);
+        book.Rating.Should().Be(rating);
+        book.Authors.Should().Be(authors);
+        book.Publishers.Should().Be(publishers);
+        book.PublishDate.Should().Be(publishDate);
+        book.NumberOfPages.Should().Be(numberOfPages);
+        book.ReadingDates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Create_Should_CreateBookWithAuthorsAndPublishers()
+    {
+        // Arrange
+        const string series = "Watchmen";
+        const string title = "Watchmen";
+        const string isbn = "9781401245252";
+        const string authors = "Alan Moore, Dave Gibbons";
+        const string publishers = "DC Comics";
+
+        // Act
+        var book = Book.Create(series, title, isbn, authors: authors, publishers: publishers);
+
+        // Assert
+        book.Authors.Should().Be(authors);
+        book.Publishers.Should().Be(publishers);
+        book.PublishDate.Should().BeNull();
+        book.NumberOfPages.Should().BeNull();
+        book.VolumeNumber.Should().Be(1);
+        book.ImageLink.Should().BeEmpty();
+        book.Rating.Should().Be(0);
+    }
+
+    [Fact]
+    public void Create_Should_CreateBookWithPublishDate()
+    {
+        // Arrange
+        const string series = "The Walking Dead";
+        const string title = "Days Gone Bye";
+        const string isbn = "9781582406190";
+        var publishDate = new DateOnly(2004, 10, 1);
+
+        // Act
+        var book = Book.Create(series, title, isbn, publishDate: publishDate);
+
+        // Assert
+        book.PublishDate.Should().Be(publishDate);
+        book.Authors.Should().BeEmpty();
+        book.Publishers.Should().BeEmpty();
+        book.NumberOfPages.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_Should_CreateBookWithNumberOfPages()
+    {
+        // Arrange
+        const string series = "Y: The Last Man";
+        const string title = "Unmanned";
+        const string isbn = "9781401219512";
+        const int numberOfPages = 128;
+
+        // Act
+        var book = Book.Create(series, title, isbn, numberOfPages: numberOfPages);
+
+        // Assert
+        book.NumberOfPages.Should().Be(numberOfPages);
+        book.Authors.Should().BeEmpty();
+        book.Publishers.Should().BeEmpty();
+        book.PublishDate.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_Should_UseDefaultValues_WhenOptionalParametersNotProvided()
+    {
+        // Arrange
+        const string series = "Fables";
+        const string title = "Volume 1";
+        const string isbn = "9781563899423";
+
+        // Act
+        var book = Book.Create(series, title, isbn);
+
+        // Assert
+        book.VolumeNumber.Should().Be(1);
+        book.ImageLink.Should().BeEmpty();
+        book.Rating.Should().Be(0);
+        book.Authors.Should().BeEmpty();
+        book.Publishers.Should().BeEmpty();
+        book.PublishDate.Should().BeNull();
+        book.NumberOfPages.Should().BeNull();
+    }
+
+    [Fact]
     public void Update_Should_UpdateAllProperties()
     {
         // Arrange
@@ -114,6 +230,125 @@ public class BookTests
         book.VolumeNumber.Should().Be(newVolumeNumber);
         book.ImageLink.Should().Be(newImageLink);
         book.Rating.Should().Be(newRating);
+    }
+
+    [Fact]
+    public void Update_Should_UpdateAllMetadataFields()
+    {
+        // Arrange
+        var originalPublishDate = new DateOnly(2020, 1, 1);
+        var book = Book.Create("Old Series", "Old Title", "1234567890",
+            authors: "Old Author", publishers: "Old Publisher",
+            publishDate: originalPublishDate, numberOfPages: 100);
+
+        const string newSeries = "Updated Series";
+        const string newTitle = "Updated Title";
+        const string newIsbn = "9876543210";
+        const int newVolumeNumber = 3;
+        const string newImageLink = "https://example.com/updated.jpg";
+        const int newRating = 4;
+        const string newAuthors = "New Author, Second Author";
+        const string newPublishers = "New Publisher";
+        var newPublishDate = new DateOnly(2024, 6, 15);
+        const int newNumberOfPages = 250;
+
+        // Act
+        book.Update(newSeries, newTitle, newIsbn, newVolumeNumber, newImageLink, newRating,
+            newAuthors, newPublishers, newPublishDate, newNumberOfPages);
+
+        // Assert
+        book.Serie.Should().Be(newSeries);
+        book.Title.Should().Be(newTitle);
+        book.ISBN.Should().Be(newIsbn);
+        book.VolumeNumber.Should().Be(newVolumeNumber);
+        book.ImageLink.Should().Be(newImageLink);
+        book.Rating.Should().Be(newRating);
+        book.Authors.Should().Be(newAuthors);
+        book.Publishers.Should().Be(newPublishers);
+        book.PublishDate.Should().Be(newPublishDate);
+        book.NumberOfPages.Should().Be(newNumberOfPages);
+    }
+
+    [Fact]
+    public void Update_Should_UpdateOnlyAuthorsAndPublishers()
+    {
+        // Arrange
+        var book = Book.Create("Series", "Title", "1234567890");
+        const string newAuthors = "Alan Moore, Dave Gibbons";
+        const string newPublishers = "DC Comics, Vertigo";
+
+        // Act
+        book.Update(book.Serie, book.Title, book.ISBN, book.VolumeNumber, book.ImageLink, book.Rating,
+            newAuthors, newPublishers);
+
+        // Assert
+        book.Authors.Should().Be(newAuthors);
+        book.Publishers.Should().Be(newPublishers);
+        book.PublishDate.Should().BeNull();
+        book.NumberOfPages.Should().BeNull();
+    }
+
+    [Fact]
+    public void Update_Should_UpdatePublishDateAndNumberOfPages()
+    {
+        // Arrange
+        var book = Book.Create("Series", "Title", "1234567890");
+        var newPublishDate = new DateOnly(2021, 3, 15);
+        const int newNumberOfPages = 320;
+
+        // Act
+        book.Update(book.Serie, book.Title, book.ISBN, book.VolumeNumber, book.ImageLink, book.Rating,
+            publishDate: newPublishDate, numberOfPages: newNumberOfPages);
+
+        // Assert
+        book.PublishDate.Should().Be(newPublishDate);
+        book.NumberOfPages.Should().Be(newNumberOfPages);
+        book.Authors.Should().BeEmpty();
+        book.Publishers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Update_Should_ClearMetadata_WhenSetToEmptyValues()
+    {
+        // Arrange
+        var originalPublishDate = new DateOnly(2020, 1, 1);
+        var book = Book.Create("Series", "Title", "1234567890",
+            authors: "Original Author", publishers: "Original Publisher",
+            publishDate: originalPublishDate, numberOfPages: 100);
+
+        // Act
+        book.Update(book.Serie, book.Title, book.ISBN, book.VolumeNumber, book.ImageLink, book.Rating,
+            "", "", null, null);
+
+        // Assert
+        book.Authors.Should().BeEmpty();
+        book.Publishers.Should().BeEmpty();
+        book.PublishDate.Should().BeNull();
+        book.NumberOfPages.Should().BeNull();
+    }
+
+    [Fact]
+    public void Update_Should_PreserveMetadata_WhenNotProvided()
+    {
+        // Arrange
+        var originalPublishDate = new DateOnly(2020, 1, 1);
+        var book = Book.Create("Old Series", "Old Title", "1234567890",
+            authors: "Original Author", publishers: "Original Publisher",
+            publishDate: originalPublishDate, numberOfPages: 100);
+
+        const string newSeries = "New Series";
+        const string newTitle = "New Title";
+
+        // Act - update basic properties without metadata parameters
+        book.Update(newSeries, newTitle, book.ISBN, book.VolumeNumber, book.ImageLink, book.Rating);
+
+        // Assert - metadata should be cleared to defaults when not provided
+        book.Serie.Should().Be(newSeries);
+        book.Title.Should().Be(newTitle);
+        book.Authors.Should().BeEmpty();
+        book.Publishers.Should().BeEmpty();
+        book.PublishDate.Should().BeNull();
+        book.NumberOfPages.Should().BeNull();
     }
 
     [Fact]

--- a/tests/Domain.UnitTests/Domain.UnitTests.csproj
+++ b/tests/Domain.UnitTests/Domain.UnitTests.csproj
@@ -12,6 +12,10 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" />
     <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp">

--- a/tests/Persistence.Integration.Tests/Persistence.Tests.csproj
+++ b/tests/Persistence.Integration.Tests/Persistence.Tests.csproj
@@ -16,6 +16,10 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" />
     <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MockQueryable.NSubstitute" />

--- a/tests/Web.Tests/Services/BooksServiceTests.cs
+++ b/tests/Web.Tests/Services/BooksServiceTests.cs
@@ -128,21 +128,22 @@ public sealed class BooksServiceTests
 
     #endregion
 
-    #region Create Tests (3 parameters)
+    #region Create Tests
 
     [Fact]
-    public async Task Create_With3Parameters_ShouldCallFullCreateWithDefaults()
+    public async Task Create_ShouldCallHandlerWithMinimalParameters()
     {
         // Arrange
         const string series = "Test Series";
         const string title = "Test Title";
         const string isbn = "978-3-16-148410-0";
+        var request = new CreateBookRequest(series, title, isbn);
         var book = Book.Create(series, title, isbn, 1, "");
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
         // Act
-        var result = await _service.Create(series, title, isbn);
+        var result = await _service.Create(request);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -156,24 +157,21 @@ public sealed class BooksServiceTests
             Arg.Any<CancellationToken>());
     }
 
-    #endregion
-
-    #region Create Tests (4 parameters)
-
     [Fact]
-    public async Task Create_With4Parameters_ShouldCallFullCreateWithDefaults()
+    public async Task Create_ShouldCallHandlerWithVolumeNumber()
     {
         // Arrange
         const string series = "Test Series";
         const string title = "Test Title";
         const string isbn = "978-3-16-148410-0";
         const int volumeNumber = 3;
+        var request = new CreateBookRequest(series, title, isbn, volumeNumber);
         var book = Book.Create(series, title, isbn, volumeNumber, "");
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
         // Act
-        var result = await _service.Create(series, title, isbn, volumeNumber);
+        var result = await _service.Create(request);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -187,12 +185,8 @@ public sealed class BooksServiceTests
             Arg.Any<CancellationToken>());
     }
 
-    #endregion
-
-    #region Create Tests (6 parameters)
-
     [Fact]
-    public async Task Create_With6Parameters_ShouldCallHandlerWithAllParameters()
+    public async Task Create_ShouldCallHandlerWithAllBasicParameters()
     {
         // Arrange
         const string series = "Test Series";
@@ -201,12 +195,13 @@ public sealed class BooksServiceTests
         const int volumeNumber = 5;
         const string imageLink = "https://example.com/cover.jpg";
         const int rating = 4;
+        var request = new CreateBookRequest(series, title, isbn, volumeNumber, imageLink, rating);
         var book = Book.Create(series, title, isbn, volumeNumber, imageLink, rating);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
         // Act
-        var result = await _service.Create(series, title, isbn, volumeNumber, imageLink, rating);
+        var result = await _service.Create(request);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -222,7 +217,7 @@ public sealed class BooksServiceTests
     }
 
     [Fact]
-    public async Task Create_With6Parameters_ShouldReturnCreatedBook()
+    public async Task Create_ShouldReturnCreatedBook()
     {
         // Arrange
         const string series = "Marvel";
@@ -231,12 +226,13 @@ public sealed class BooksServiceTests
         const int volumeNumber = 10;
         const string imageLink = "https://example.com/spiderman.jpg";
         const int rating = 5;
+        var request = new CreateBookRequest(series, title, isbn, volumeNumber, imageLink, rating);
         var expectedBook = Book.Create(series, title, isbn, volumeNumber, imageLink, rating);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(expectedBook);
 
         // Act
-        var result = await _service.Create(series, title, isbn, volumeNumber, imageLink, rating);
+        var result = await _service.Create(request);
 
         // Assert
         Guard.Against.Null(result.Value);
@@ -251,16 +247,17 @@ public sealed class BooksServiceTests
     }
 
     [Fact]
-    public async Task Create_With6Parameters_ShouldPassCancellationToken()
+    public async Task Create_ShouldPassCancellationToken()
     {
         // Arrange
         using var cts = new CancellationTokenSource();
+        var request = new CreateBookRequest("Series", "Title", "978-3-16-148410-0");
         var book = Book.Create("Series", "Title", "978-3-16-148410-0");
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
         // Act
-        await _service.Create("Series", "Title", "978-3-16-148410-0", 1, "", 0, cts.Token);
+        await _service.Create(request, cts.Token);
 
         // Assert
         await _createBookHandler.Received(1).Handle(
@@ -269,7 +266,7 @@ public sealed class BooksServiceTests
     }
 
     [Fact]
-    public async Task Create_With6Parameters_ShouldForwardEmptyMetadataToFullOverload()
+    public async Task Create_ShouldForwardEmptyMetadataByDefault()
     {
         // Arrange
         const string series = "Test Series";
@@ -278,12 +275,13 @@ public sealed class BooksServiceTests
         const int volumeNumber = 5;
         const string imageLink = "https://example.com/cover.jpg";
         const int rating = 4;
+        var request = new CreateBookRequest(series, title, isbn, volumeNumber, imageLink, rating);
         var book = Book.Create(series, title, isbn, volumeNumber, imageLink, rating);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
         // Act
-        var result = await _service.Create(series, title, isbn, volumeNumber, imageLink, rating);
+        var result = await _service.Create(request);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -302,12 +300,8 @@ public sealed class BooksServiceTests
             Arg.Any<CancellationToken>());
     }
 
-    #endregion
-
-    #region Create Tests (10 parameters - with metadata)
-
     [Fact]
-    public async Task Create_With10Parameters_ShouldCallHandlerWithAllMetadataFields()
+    public async Task Create_ShouldCallHandlerWithAllMetadataFields()
     {
         // Arrange
         const string series = "Saga";
@@ -320,12 +314,13 @@ public sealed class BooksServiceTests
         const string publishers = "Image Comics";
         var publishDate = new DateOnly(2012, 10, 10);
         const int numberOfPages = 160;
+        var request = new CreateBookRequest(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
         var book = Book.Create(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
         // Act
-        var result = await _service.Create(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+        var result = await _service.Create(request);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -345,7 +340,7 @@ public sealed class BooksServiceTests
     }
 
     [Fact]
-    public async Task Create_With10Parameters_ShouldReturnCreatedBookWithMetadata()
+    public async Task Create_ShouldReturnCreatedBookWithMetadata()
     {
         // Arrange
         const string series = "Watchmen";
@@ -358,12 +353,13 @@ public sealed class BooksServiceTests
         const string publishers = "DC Comics";
         var publishDate = new DateOnly(1987, 9, 1);
         const int numberOfPages = 320;
+        var request = new CreateBookRequest(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
         var expectedBook = Book.Create(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(expectedBook);
 
         // Act
-        var result = await _service.Create(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+        var result = await _service.Create(request);
 
         // Assert
         Guard.Against.Null(result.Value);
@@ -382,17 +378,18 @@ public sealed class BooksServiceTests
     }
 
     [Fact]
-    public async Task Create_With10Parameters_ShouldPassCancellationToken()
+    public async Task Create_ShouldPassCancellationTokenWithMetadata()
     {
         // Arrange
         using var cts = new CancellationTokenSource();
         var publishDate = new DateOnly(2020, 1, 1);
+        var request = new CreateBookRequest("Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 100);
         var book = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 100);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
         // Act
-        await _service.Create("Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 100, cts.Token);
+        await _service.Create(request, cts.Token);
 
         // Assert
         await _createBookHandler.Received(1).Handle(
@@ -401,7 +398,7 @@ public sealed class BooksServiceTests
     }
 
     [Fact]
-    public async Task Create_With10Parameters_ShouldHandleNullPublishDate()
+    public async Task Create_ShouldHandleNullPublishDate()
     {
         // Arrange
         const string series = "Unknown Date Comic";
@@ -409,12 +406,13 @@ public sealed class BooksServiceTests
         const string isbn = "978-3-16-148410-0";
         const string authors = "Unknown Author";
         const string publishers = "Unknown Publisher";
+        var request = new CreateBookRequest(series, title, isbn, 1, "", 0, authors, publishers, null, null);
         var book = Book.Create(series, title, isbn, 1, "", 0, authors, publishers, null, null);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
         // Act
-        var result = await _service.Create(series, title, isbn, 1, "", 0, authors, publishers, null, null);
+        var result = await _service.Create(request);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -428,15 +426,16 @@ public sealed class BooksServiceTests
     }
 
     [Fact]
-    public async Task Create_With10Parameters_ShouldHandleEmptyAuthorsAndPublishers()
+    public async Task Create_ShouldHandleEmptyAuthorsAndPublishers()
     {
         // Arrange
+        var request = new CreateBookRequest("Series", "Title", "978-3-16-148410-0");
         var book = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", 0, "", "", null, null);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
         // Act
-        var result = await _service.Create("Series", "Title", "978-3-16-148410-0", 1, "", 0, "", "", null, null);
+        var result = await _service.Create(request);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -448,17 +447,18 @@ public sealed class BooksServiceTests
     }
 
     [Fact]
-    public async Task Create_With10Parameters_ShouldHandleMultipleAuthorsAndPublishers()
+    public async Task Create_ShouldHandleMultipleAuthorsAndPublishers()
     {
         // Arrange
         const string authors = "Stan Lee, Jack Kirby, Steve Ditko";
         const string publishers = "Marvel Comics, Timely Comics";
+        var request = new CreateBookRequest("Marvel", "Fantastic Four", "978-3-16-148410-0", 1, "", 0, authors, publishers);
         var book = Book.Create("Marvel", "Fantastic Four", "978-3-16-148410-0", 1, "", 0, authors, publishers, null, null);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
         // Act
-        var result = await _service.Create("Marvel", "Fantastic Four", "978-3-16-148410-0", 1, "", 0, authors, publishers, null, null);
+        var result = await _service.Create(request);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -471,10 +471,10 @@ public sealed class BooksServiceTests
 
     #endregion
 
-    #region Update Tests (10 parameters - with metadata)
+    #region Update Tests
 
     [Fact]
-    public async Task Update_With10Parameters_ShouldCallHandlerWithAllMetadataFields()
+    public async Task Update_ShouldCallHandlerWithAllMetadataFields()
     {
         // Arrange
         var bookId = Guid.CreateVersion7();
@@ -488,12 +488,13 @@ public sealed class BooksServiceTests
         const string publishers = "Image Comics";
         var publishDate = new DateOnly(2004, 10, 1);
         const int numberOfPages = 144;
+        var request = new UpdateBookRequest(bookId.ToString(), series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
         var book = Book.Create(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
         _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
         // Act
-        var result = await _service.Update(bookId.ToString(), series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+        var result = await _service.Update(request);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -514,7 +515,7 @@ public sealed class BooksServiceTests
     }
 
     [Fact]
-    public async Task Update_With10Parameters_ShouldReturnUpdatedBookWithMetadata()
+    public async Task Update_ShouldReturnUpdatedBookWithMetadata()
     {
         // Arrange
         var bookId = Guid.CreateVersion7();
@@ -528,12 +529,13 @@ public sealed class BooksServiceTests
         const string publishers = "Vertigo";
         var publishDate = new DateOnly(2003, 4, 1);
         const int numberOfPages = 128;
+        var request = new UpdateBookRequest(bookId.ToString(), series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
         var expectedBook = Book.Create(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
         _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(expectedBook);
 
         // Act
-        var result = await _service.Update(bookId.ToString(), series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+        var result = await _service.Update(request);
 
         // Assert
         Guard.Against.Null(result.Value);
@@ -548,18 +550,19 @@ public sealed class BooksServiceTests
     }
 
     [Fact]
-    public async Task Update_With10Parameters_ShouldPassCancellationToken()
+    public async Task Update_ShouldPassCancellationToken()
     {
         // Arrange
         var bookId = Guid.CreateVersion7();
         using var cts = new CancellationTokenSource();
         var publishDate = new DateOnly(2020, 5, 15);
+        var request = new UpdateBookRequest(bookId.ToString(), "Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 200);
         var book = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 200);
         _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
         // Act
-        await _service.Update(bookId.ToString(), "Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 200, cts.Token);
+        await _service.Update(request, cts.Token);
 
         // Assert
         await _updateBookHandler.Received(1).Handle(
@@ -568,14 +571,15 @@ public sealed class BooksServiceTests
     }
 
     [Fact]
-    public async Task Update_With10Parameters_ShouldReturnValidationError_WhenIdIsNull()
+    public async Task Update_ShouldReturnValidationError_WhenIdIsNull()
     {
         // Arrange
         string? id = null;
         var publishDate = new DateOnly(2020, 1, 1);
+        var request = new UpdateBookRequest(id, "Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 100);
 
         // Act
-        var result = await _service.Update(id, "Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 100);
+        var result = await _service.Update(request);
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -584,14 +588,15 @@ public sealed class BooksServiceTests
     }
 
     [Fact]
-    public async Task Update_With10Parameters_ShouldReturnValidationError_WhenIdIsInvalidGuid()
+    public async Task Update_ShouldReturnValidationError_WhenIdIsInvalidGuid()
     {
         // Arrange
         const string id = "not-a-valid-guid";
         var publishDate = new DateOnly(2020, 1, 1);
+        var request = new UpdateBookRequest(id, "Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 100);
 
         // Act
-        var result = await _service.Update(id, "Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 100);
+        var result = await _service.Update(request);
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -600,16 +605,17 @@ public sealed class BooksServiceTests
     }
 
     [Fact]
-    public async Task Update_With10Parameters_ShouldHandleNullMetadata()
+    public async Task Update_ShouldHandleNullMetadata()
     {
         // Arrange
         var bookId = Guid.CreateVersion7();
+        var request = new UpdateBookRequest(bookId.ToString(), "Series", "Title", "978-3-16-148410-0", 1, "", 0);
         var book = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", 0, "", "", null, null);
         _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
         // Act
-        var result = await _service.Update(bookId.ToString(), "Series", "Title", "978-3-16-148410-0", 1, "", 0, "", "", null, null);
+        var result = await _service.Update(request);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -623,18 +629,18 @@ public sealed class BooksServiceTests
     }
 
     [Fact]
-    public async Task Update_With10Parameters_ShouldAllowUpdatingOnlyMetadata()
+    public async Task Update_ShouldAllowUpdatingOnlyMetadata()
     {
         // Arrange
         var bookId = Guid.CreateVersion7();
-        var originalPublishDate = new DateOnly(2020, 1, 1);
         var newPublishDate = new DateOnly(2021, 6, 15);
+        var request = new UpdateBookRequest(bookId.ToString(), "Series", "Title", "978-3-16-148410-0", 1, "", 0, "New Author", "New Publisher", newPublishDate, 250);
         var book = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", 0, "New Author", "New Publisher", newPublishDate, 250);
         _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
         // Act
-        var result = await _service.Update(bookId.ToString(), "Series", "Title", "978-3-16-148410-0", 1, "", 0, "New Author", "New Publisher", newPublishDate, 250);
+        var result = await _service.Update(request);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -645,40 +651,6 @@ public sealed class BooksServiceTests
                 c.PublishDate == newPublishDate &&
                 c.NumberOfPages == 250),
             Arg.Any<CancellationToken>());
-    }
-
-    #endregion
-
-    #region Update Tests
-
-    [Fact]
-    public async Task Update_ShouldReturnValidationError_WhenIdIsNull()
-    {
-        // Arrange
-        string? id = null;
-
-        // Act
-        var result = await _service.Update(id, "Series", "Title", "978-3-16-148410-0", 1, "", 0);
-
-        // Assert
-        result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(BooksError.ValidationError);
-        await _updateBookHandler.DidNotReceive().Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task Update_ShouldReturnValidationError_WhenIdIsInvalidGuid()
-    {
-        // Arrange
-        const string id = "not-a-guid";
-
-        // Act
-        var result = await _service.Update(id, "Series", "Title", "978-3-16-148410-0", 1, "", 0);
-
-        // Assert
-        result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(BooksError.ValidationError);
-        await _updateBookHandler.DidNotReceive().Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -692,14 +664,13 @@ public sealed class BooksServiceTests
         const int volumeNumber = 7;
         const string imageLink = "https://example.com/updated.jpg";
         const int rating = 3;
+        var request = new UpdateBookRequest(bookId.ToString(), series, title, isbn, volumeNumber, imageLink, rating);
         var book = Book.Create(series, title, isbn, volumeNumber, imageLink, rating);
-        _getBookByIdHandler.Handle(Arg.Any<GetBookByIdQuery>(), Arg.Any<CancellationToken>())
-            .Returns(book);
         _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
         // Act
-        var result = await _service.Update(bookId.ToString(), series, title, isbn, volumeNumber, imageLink, rating);
+        var result = await _service.Update(request);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -726,14 +697,13 @@ public sealed class BooksServiceTests
         const int volumeNumber = 15;
         const string imageLink = "https://example.com/batman.jpg";
         const int rating = 5;
+        var request = new UpdateBookRequest(bookId.ToString(), series, title, isbn, volumeNumber, imageLink, rating);
         var expectedBook = Book.Create(series, title, isbn, volumeNumber, imageLink, rating);
-        _getBookByIdHandler.Handle(Arg.Any<GetBookByIdQuery>(), Arg.Any<CancellationToken>())
-            .Returns(expectedBook);
         _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(expectedBook);
 
         // Act
-        var result = await _service.Update(bookId.ToString(), series, title, isbn, volumeNumber, imageLink, rating);
+        var result = await _service.Update(request);
 
         // Assert
         Guard.Against.Null(result.Value);
@@ -743,74 +713,6 @@ public sealed class BooksServiceTests
         result.Value.Title.Should().Be(title);
         result.Value.VolumeNumber.Should().Be(volumeNumber);
         result.Value.Rating.Should().Be(rating);
-    }
-
-    [Fact]
-    public async Task Update_ShouldPassCancellationToken()
-    {
-        // Arrange
-        var bookId = Guid.CreateVersion7();
-        using var cts = new CancellationTokenSource();
-        var book = Book.Create("Series", "Title", "978-3-16-148410-0");
-        _getBookByIdHandler.Handle(Arg.Any<GetBookByIdQuery>(), Arg.Any<CancellationToken>())
-            .Returns(book);
-        _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
-            .Returns(book);
-
-        // Act
-        await _service.Update(bookId.ToString(), "Series", "Title", "978-3-16-148410-0", 1, "", 0, cts.Token);
-
-        // Assert
-        await _updateBookHandler.Received(1).Handle(
-            Arg.Any<UpdateBookCommand>(),
-            Arg.Is<CancellationToken>(ct => ct == cts.Token));
-    }
-
-    [Fact]
-    public async Task Update_With7Parameters_ShouldPreserveMetadata_WhenBookHasExistingMetadata()
-    {
-        // Arrange
-        var bookId = Guid.CreateVersion7();
-        var publishDate = new DateOnly(2023, 6, 15);
-        var existingBook = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", 0,
-            "Brian K. Vaughan", "Image Comics", publishDate, 160);
-        _getBookByIdHandler.Handle(Arg.Any<GetBookByIdQuery>(), Arg.Any<CancellationToken>())
-            .Returns(existingBook);
-        _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
-            .Returns(existingBook);
-
-        // Act
-        var result = await _service.Update(bookId.ToString(), "Updated Series", "Updated Title", "978-3-16-148410-0", 2, "http://example.com/img.jpg", 5);
-
-        // Assert
-        result.IsSuccess.Should().BeTrue();
-        await _updateBookHandler.Received(1).Handle(
-            Arg.Is<UpdateBookCommand>(c =>
-                c.Id == bookId &&
-                c.Serie == "Updated Series" &&
-                c.Title == "Updated Title" &&
-                c.Authors == "Brian K. Vaughan" &&
-                c.Publishers == "Image Comics" &&
-                c.PublishDate == publishDate &&
-                c.NumberOfPages == 160),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task Update_With7Parameters_ShouldReturnFailure_WhenBookNotFound()
-    {
-        // Arrange
-        var bookId = Guid.CreateVersion7();
-        _getBookByIdHandler.Handle(Arg.Any<GetBookByIdQuery>(), Arg.Any<CancellationToken>())
-            .Returns(Result<Book>.Failure(BooksError.NotFound));
-
-        // Act
-        var result = await _service.Update(bookId.ToString(), "Series", "Title", "978-3-16-148410-0", 1, "", 0);
-
-        // Assert
-        result.IsFailure.Should().BeTrue();
-        result.Error.Should().Be(BooksError.NotFound);
-        await _updateBookHandler.DidNotReceive().Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>());
     }
 
     #endregion

--- a/tests/Web.Tests/Validators/BookUiDtoTests.cs
+++ b/tests/Web.Tests/Validators/BookUiDtoTests.cs
@@ -21,6 +21,11 @@ public sealed class BookUiDtoTests
         dto.ISBN.Should().Be(string.Empty);
         dto.VolumeNumber.Should().Be(1);
         dto.ImageLink.Should().Be(string.Empty);
+        dto.Rating.Should().Be(0);
+        dto.Authors.Should().Be(string.Empty);
+        dto.Publishers.Should().Be(string.Empty);
+        dto.PublishDate.Should().BeNull();
+        dto.NumberOfPages.Should().BeNull();
         dto.Id.Should().Be(default(Guid));
         dto.CreatedOnUtc.Should().Be(default);
         dto.ModifiedOnUtc.Should().BeNull();
@@ -113,8 +118,13 @@ public sealed class BookUiDtoTests
         const string isbn = "978-1-401263-119-5";
         const int volumeNumber = 1;
         const string imageLink = "https://example.com/batman.jpg";
+        const int rating = 5;
+        const string authors = "Frank Miller";
+        const string publishers = "DC Comics";
+        var publishDate = new DateOnly(1986, 2, 1);
+        const int numberOfPages = 224;
 
-        var book = Book.Create(serie, title, isbn, volumeNumber, imageLink);
+        var book = Book.Create(serie, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
         book.CreatedOnUtc = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
         book.ModifiedOnUtc = new DateTime(2024, 1, 20, 14, 45, 0, DateTimeKind.Utc);
 
@@ -128,6 +138,11 @@ public sealed class BookUiDtoTests
         dto.ISBN.Should().Be(isbn);
         dto.VolumeNumber.Should().Be(volumeNumber);
         dto.ImageLink.Should().Be(imageLink);
+        dto.Rating.Should().Be(rating);
+        dto.Authors.Should().Be(authors);
+        dto.Publishers.Should().Be(publishers);
+        dto.PublishDate.Should().Be(publishDate);
+        dto.NumberOfPages.Should().Be(numberOfPages);
         dto.CreatedOnUtc.Should().Be(book.CreatedOnUtc);
         dto.ModifiedOnUtc.Should().Be(book.ModifiedOnUtc);
     }
@@ -146,6 +161,10 @@ public sealed class BookUiDtoTests
         dto.Title.Should().Be(string.Empty);
         dto.ISBN.Should().Be(string.Empty);
         dto.ImageLink.Should().Be(string.Empty);
+        dto.Authors.Should().Be(string.Empty);
+        dto.Publishers.Should().Be(string.Empty);
+        dto.PublishDate.Should().BeNull();
+        dto.NumberOfPages.Should().BeNull();
     }
 
     [Fact]
@@ -210,8 +229,13 @@ public sealed class BookUiDtoTests
         const string isbn = "978-1-582406-72-1";
         const int volumeNumber = 1;
         const string imageLink = "https://cdn.example.com/walking-dead-vol1.jpg";
+        const int rating = 4;
+        const string authors = "Robert Kirkman";
+        const string publishers = "Image Comics";
+        var publishDate = new DateOnly(2004, 10, 1);
+        const int numberOfPages = 144;
 
-        var book = Book.Create(serie, title, isbn, volumeNumber, imageLink);
+        var book = Book.Create(serie, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
         var createdDate = new DateTime(2023, 6, 1, 8, 0, 0, DateTimeKind.Utc);
         var modifiedDate = new DateTime(2023, 6, 15, 16, 30, 0, DateTimeKind.Utc);
         book.CreatedOnUtc = createdDate;
@@ -227,6 +251,11 @@ public sealed class BookUiDtoTests
         dto.ISBN.Should().Be(isbn);
         dto.VolumeNumber.Should().Be(volumeNumber);
         dto.ImageLink.Should().Be(imageLink);
+        dto.Rating.Should().Be(rating);
+        dto.Authors.Should().Be(authors);
+        dto.Publishers.Should().Be(publishers);
+        dto.PublishDate.Should().Be(publishDate);
+        dto.NumberOfPages.Should().Be(numberOfPages);
         dto.CreatedOnUtc.Should().Be(createdDate);
         dto.ModifiedOnUtc.Should().Be(modifiedDate);
     }
@@ -289,6 +318,7 @@ public sealed class BookUiDtoTests
         const string title = "Ñoño's Ädventure!";
         const string isbn = "978-ä-öü-ß";
 
+
         var book = Book.Create(serie, title, isbn);
 
         // Act
@@ -298,6 +328,135 @@ public sealed class BookUiDtoTests
         dto.Serie.Should().Be(serie);
         dto.Title.Should().Be(title);
         dto.ISBN.Should().Be(isbn);
+    }
+
+    [Fact]
+    public void Convert_ShouldHandleMultipleAuthors()
+    {
+        // Arrange
+        const string authors = "Stan Lee, Jack Kirby, Steve Ditko";
+        var book = Book.Create("Marvel", "The Avengers", "978-0-785-12345-6", 1, "", 0, authors, "", null, null);
+
+        // Act
+        var dto = BookUiDto.Convert(book);
+
+        // Assert
+        dto.Authors.Should().Be(authors);
+    }
+
+    [Fact]
+    public void Convert_ShouldHandleMultiplePublishers()
+    {
+        // Arrange
+        const string publishers = "Marvel Comics, DC Comics";
+        var book = Book.Create("Crossover", "JLA/Avengers", "978-0-785-11234-5", 1, "", 0, "", publishers, null, null);
+
+        // Act
+        var dto = BookUiDto.Convert(book);
+
+        // Assert
+        dto.Publishers.Should().Be(publishers);
+    }
+
+    [Fact]
+    public void Convert_ShouldHandlePublishDate_WhenProvided()
+    {
+        // Arrange
+        var publishDate = new DateOnly(1962, 8, 1); // Amazing Fantasy #15
+        var book = Book.Create("Amazing Fantasy", "Spider-Man's First Appearance", "N/A", 15, "", 0, "Stan Lee, Steve Ditko", "Marvel Comics", publishDate, 11);
+
+        // Act
+        var dto = BookUiDto.Convert(book);
+
+        // Assert
+        dto.PublishDate.Should().Be(publishDate);
+    }
+
+    [Fact]
+    public void Convert_ShouldHandleNullPublishDate()
+    {
+        // Arrange
+        var book = Book.Create("Unknown", "Mystery Comic", "ISBN", 1, "", 0, "", "", null, null);
+
+        // Act
+        var dto = BookUiDto.Convert(book);
+
+        // Assert
+        dto.PublishDate.Should().BeNull();
+    }
+
+    [Fact]
+    public void Convert_ShouldHandleNumberOfPages_WhenProvided()
+    {
+        // Arrange
+        const int numberOfPages = 320;
+        var book = Book.Create("Watchmen", "Watchmen", "978-0-930289-23-2", 1, "", 0, "Alan Moore", "DC Comics", new DateOnly(1987, 9, 1), numberOfPages);
+
+        // Act
+        var dto = BookUiDto.Convert(book);
+
+        // Assert
+        dto.NumberOfPages.Should().Be(numberOfPages);
+    }
+
+    [Fact]
+    public void Convert_ShouldHandleNullNumberOfPages()
+    {
+        // Arrange
+        var book = Book.Create("Unknown", "Mystery Pages", "ISBN");
+
+        // Act
+        var dto = BookUiDto.Convert(book);
+
+        // Assert
+        dto.NumberOfPages.Should().BeNull();
+    }
+
+    [Fact]
+    public void Convert_ShouldHandleEmptyAuthorsAndPublishers()
+    {
+        // Arrange
+        var book = Book.Create("Series", "Title", "ISBN", 1, "", 0, "", "", null, null);
+
+        // Act
+        var dto = BookUiDto.Convert(book);
+
+        // Assert
+        dto.Authors.Should().Be(string.Empty);
+        dto.Publishers.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void Convert_ShouldHandleAllMetadataFields_WithRealisticComicData()
+    {
+        // Arrange
+        const string serie = "Saga";
+        const string title = "Saga, Volume 1";
+        const string isbn = "978-1-60706-601-9";
+        const int volumeNumber = 1;
+        const string imageLink = "https://cdn.example.com/saga-vol1.jpg";
+        const int rating = 5;
+        const string authors = "Brian K. Vaughan, Fiona Staples";
+        const string publishers = "Image Comics";
+        var publishDate = new DateOnly(2012, 10, 10);
+        const int numberOfPages = 160;
+
+        var book = Book.Create(serie, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+
+        // Act
+        var dto = BookUiDto.Convert(book);
+
+        // Assert
+        dto.Serie.Should().Be(serie);
+        dto.Title.Should().Be(title);
+        dto.ISBN.Should().Be(isbn);
+        dto.VolumeNumber.Should().Be(volumeNumber);
+        dto.ImageLink.Should().Be(imageLink);
+        dto.Rating.Should().Be(rating);
+        dto.Authors.Should().Be(authors);
+        dto.Publishers.Should().Be(publishers);
+        dto.PublishDate.Should().Be(publishDate);
+        dto.NumberOfPages.Should().Be(numberOfPages);
     }
 
     #endregion

--- a/tests/Web.Tests/Validators/BookValidatorTests.cs
+++ b/tests/Web.Tests/Validators/BookValidatorTests.cs
@@ -759,6 +759,312 @@ public sealed class BookValidatorTests
 
     #endregion
 
+    #region Authors Validation Tests
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenAuthorsExceedsMaxLength()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            Authors = new string('A', 201)
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.PropertyName == nameof(BookUiDto.Authors));
+        result.Errors.Should().ContainSingle(e => e.ErrorMessage == "Authors must not exceed 200 characters.");
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenAuthorsIsAtMaxLength()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            Authors = new string('A', 200)
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenAuthorsIsEmpty()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            Authors = string.Empty
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Publishers Validation Tests
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenPublishersExceedsMaxLength()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            Publishers = new string('A', 201)
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.PropertyName == nameof(BookUiDto.Publishers));
+        result.Errors.Should().ContainSingle(e => e.ErrorMessage == "Publishers must not exceed 200 characters.");
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenPublishersIsAtMaxLength()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            Publishers = new string('A', 200)
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenPublishersIsEmpty()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            Publishers = string.Empty
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region NumberOfPages Validation Tests
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenNumberOfPagesIsZero()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            NumberOfPages = 0
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.PropertyName == nameof(BookUiDto.NumberOfPages));
+        result.Errors.Should().ContainSingle(e => e.ErrorMessage == "Number of pages must be greater than 0.");
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenNumberOfPagesIsNegative()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            NumberOfPages = -5
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.PropertyName == nameof(BookUiDto.NumberOfPages));
+        result.Errors.Should().ContainSingle(e => e.ErrorMessage == "Number of pages must be greater than 0.");
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenNumberOfPagesIsNull()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            NumberOfPages = null
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenNumberOfPagesIsPositive()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            NumberOfPages = 160
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region PublishDate Validation Tests
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenPublishDateIsInTheFuture()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            PublishDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30))
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.PropertyName == nameof(BookUiDto.PublishDate));
+        result.Errors.Should().ContainSingle(e => e.ErrorMessage == "Publish date must not be in the future.");
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenPublishDateIsNull()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            PublishDate = null
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenPublishDateIsToday()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            PublishDate = DateOnly.FromDateTime(DateTime.UtcNow)
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenPublishDateIsInThePast()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            PublishDate = new DateOnly(1986, 2, 1)
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    #endregion
+
     #region Edge Cases Tests
 
     [Fact]

--- a/tests/Web.Tests/Web.Tests.csproj
+++ b/tests/Web.Tests/Web.Tests.csproj
@@ -12,6 +12,10 @@
 	<ItemGroup>
 		<PackageReference Include="AwesomeAssertions" />
 		<PackageReference Include="bunit" />
+		<PackageReference Include="coverlet.collector">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MockQueryable.NSubstitute" />
 		<PackageReference Include="NSubstitute" />


### PR DESCRIPTION
Add book metadata fields and update schema/UI

Books now support authors, publishers, publish date, and number of pages. Updated domain model, DTOs, commands, handlers, and UI to handle these fields. Comic search service parses and returns metadata. Added migration for new columns. Updated service interfaces and appsettings.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Books now store and display Authors, Publishers, Publish Date, and Number of Pages; create/update flows and UI forms/summary pages propagate these fields and database migrations persist them.

* **Improvements**
  * Enhanced publish-date parsing, ISBN normalization, updated date display format, length constraints, and validations (publish date not in future; page count > 0).

* **Tests**
  * Expanded unit and integration tests covering metadata mapping, persistence, parsing, validation, and service behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->