### PR TITLE
fix: Update baseBranches in renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,5 +7,6 @@
     ":semanticCommitTypeAll(fix)"
   ],
   "prConcurrentLimit": 10,
-  "baseBranches": ["main","net6"]
+  "baseBranches": ["main"]
+
 }

--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <PackageId>mcm.Application</PackageId>
     <!-- x-release-please-start-version -->
-    <Version>10.0.1</Version>
+    <Version>10.0.2</Version>
     <!-- x-release-please-end -->
     <Authors>Nicolas DUFAUT (nicolas.dufaut@gmail.com)</Authors>
     <Product>MCM</Product>

--- a/Domain/Domain.csproj
+++ b/Domain/Domain.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <PackageId>mcm.Domain</PackageId>
     <!-- x-release-please-start-version -->
-    <Version>10.0.1</Version>
+    <Version>10.0.2</Version>
     <!-- x-release-please-end -->
     <Authors>Nicolas DUFAUT (nicolas.dufaut@gmail.com)</Authors>
     <Product>MCM</Product>

--- a/Persistence/Persistence.csproj
+++ b/Persistence/Persistence.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <PackageId>mcm.Persistence</PackageId>
     <!-- x-release-please-start-version -->
-    <Version>10.0.1</Version>
+    <Version>10.0.2</Version>
     <!-- x-release-please-end -->
     <Authors>Nicolas DUFAUT (nicolas.dufaut@gmail.com)</Authors>
     <Product>MCM</Product>

--- a/Web/Web.csproj
+++ b/Web/Web.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <PackageId>mcm.Web</PackageId>
     <!-- x-release-please-start-version -->
-    <Version>10.0.1</Version>
+    <Version>10.0.2</Version>
     <!-- x-release-please-end -->
     <Authors>Nicolas DUFAUT (nicolas.dufaut@gmail.com)</Authors>
     <Product>MCM</Product>


### PR DESCRIPTION
Removed 'net6' from baseBranches in Renovate config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency-management configuration to target the main branch only.
  * Bumped product version to 10.0.2 across components, reflecting a minor release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->