### PR TITLE
feat: add Google Books fallback for ISBN comic search

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,9 @@
       "Bash(dotnet format:*)",
       "Bash(dotnet --version:*)",
       "Bash(dotnet list package:*)",
-      "Bash(dotnet restore:*)"
+      "Bash(dotnet restore:*)",
+      "Bash(find:*)",
+      "WebFetch(domain:www.googleapis.com)"
     ]
   }
 }

--- a/Application/ComicInfoSearch/ComicSearchService.cs
+++ b/Application/ComicInfoSearch/ComicSearchService.cs
@@ -10,15 +10,18 @@ public partial class ComicSearchService : IComicSearchService
     private static Serilog.ILogger Log => Serilog.Log.ForContext<ComicSearchService>();
 
     private readonly IOpenLibraryService _openLibraryService;
+    private readonly IGoogleBooksService _googleBooksService;
     private readonly ICloudinaryService _cloudinaryService;
     private readonly CloudinarySettings _cloudinarySettings;
 
     public ComicSearchService(
         IOpenLibraryService openLibraryService,
+        IGoogleBooksService googleBooksService,
         ICloudinaryService cloudinaryService,
         IOptions<CloudinarySettings> cloudinarySettings)
     {
         _openLibraryService = openLibraryService;
+        _googleBooksService = googleBooksService;
         _cloudinaryService = cloudinaryService;
         _cloudinarySettings = cloudinarySettings.Value;
     }
@@ -27,48 +30,33 @@ public partial class ComicSearchService : IComicSearchService
     {
         try
         {
+            // Try OpenLibrary first
             var result = await _openLibraryService.SearchByIsbnAsync(isbn, cancellationToken);
 
-            if (!result.Found)
+            if (result.Found)
             {
-                Log.Warning("No data found for ISBN {Isbn}", isbn);
-                return CreateNotFoundResult(isbn);
+                Log.Information("Book found via OpenLibrary for ISBN {Isbn}", isbn);
+                return await MapBookResultToComicSearchResultAsync(
+                    result.Title, result.Subtitle, result.Authors, result.Publishers,
+                    result.PublishDate, result.NumberOfPages, result.CoverUrl,
+                    isbn, cancellationToken);
             }
 
-            // Extract series and volume from title if possible
-            // OpenLibrary often has titles like "Series Name - Tome 1" or "Series Name, Vol. 2"
-            var (serie, volumeNumber) = ParseVolumeAndSerie(result.Title);
+            // Fallback to Google Books
+            Log.Information("OpenLibrary returned no result for ISBN {Isbn}, trying Google Books", isbn);
+            var googleResult = await _googleBooksService.SearchByIsbnAsync(isbn, cancellationToken);
 
-            var title = string.IsNullOrEmpty(result.Subtitle) ? result.Title : result.Subtitle;
-
-            // Upload cover to Cloudinary if available
-            var imageUrl = string.Empty;
-            if (result.CoverUrl != null)
+            if (googleResult.Found)
             {
-                imageUrl = await UploadCoverToCloudinaryAsync(result.CoverUrl, isbn, cancellationToken);
+                Log.Information("Book found via Google Books for ISBN {Isbn}", isbn);
+                return await MapBookResultToComicSearchResultAsync(
+                    googleResult.Title, googleResult.Subtitle, googleResult.Authors, googleResult.Publishers,
+                    googleResult.PublishDate, googleResult.NumberOfPages, googleResult.CoverUrl,
+                    isbn, cancellationToken);
             }
 
-            // Combine authors and publishers as comma-separated strings
-            var authors = string.Join(", ", result.Authors);
-            var publishers = string.Join(", ", result.Publishers);
-
-            // Parse publish date from OpenLibrary format
-            var publishDate = ParsePublishDate(result.PublishDate);
-
-            Log.Information("Found book: {Title} - {Serie} Vol.{Volume}", title, serie, volumeNumber);
-
-            return new ComicSearchResult(
-                Title: title,
-                Serie: serie,
-                Isbn: isbn,
-                VolumeNumber: volumeNumber,
-                ImageUrl: imageUrl,
-                Authors: authors,
-                Publishers: publishers,
-                PublishDate: publishDate,
-                NumberOfPages: result.NumberOfPages,
-                Found: true
-            );
+            Log.Warning("No data found for ISBN {Isbn} in any provider", isbn);
+            return CreateNotFoundResult(isbn);
         }
         catch (HttpRequestException ex)
         {
@@ -90,6 +78,50 @@ public partial class ComicSearchService : IComicSearchService
             Log.Warning(ex, "Search cancelled for ISBN {Isbn}", isbn);
             return CreateNotFoundResult(isbn);
         }
+    }
+
+    private async Task<ComicSearchResult> MapBookResultToComicSearchResultAsync(
+        string resultTitle,
+        string? subtitle,
+        IReadOnlyList<string> resultAuthors,
+        IReadOnlyList<string> resultPublishers,
+        string? publishDateString,
+        int? numberOfPages,
+        Uri? coverUrl,
+        string isbn,
+        CancellationToken cancellationToken)
+    {
+        var (serie, volumeNumber) = ParseVolumeAndSerie(resultTitle);
+
+        // If subtitle exists, use it as title; otherwise use series name
+        // This strips volume info from the title (e.g. "Fullmetal Alchemist Tome 23" → "Fullmetal Alchemist")
+        var title = string.IsNullOrEmpty(subtitle) ? serie : subtitle;
+
+        // Upload cover to Cloudinary if available
+        var imageUrl = string.Empty;
+        if (coverUrl != null)
+        {
+            imageUrl = await UploadCoverToCloudinaryAsync(coverUrl, isbn, cancellationToken);
+        }
+
+        var authors = string.Join(", ", resultAuthors);
+        var publishers = string.Join(", ", resultPublishers);
+        var publishDate = ParsePublishDate(publishDateString);
+
+        Log.Information("Found book: {Title} - {Serie} Vol.{Volume}", title, serie, volumeNumber);
+
+        return new ComicSearchResult(
+            Title: title,
+            Serie: serie,
+            Isbn: isbn,
+            VolumeNumber: volumeNumber,
+            ImageUrl: imageUrl,
+            Authors: authors,
+            Publishers: publishers,
+            PublishDate: publishDate,
+            NumberOfPages: numberOfPages,
+            Found: true
+        );
     }
 
     private async Task<string> UploadCoverToCloudinaryAsync(Uri coverUrl, string isbn, CancellationToken cancellationToken)
@@ -122,6 +154,10 @@ public partial class ComicSearchService : IComicSearchService
     [GeneratedRegex(@"^(.+?)\s*-\s*tome\s+(\d+)", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 1000)]
     private static partial Regex DashTomePattern();
 
+    // "Soda Tome 1" or "Fullmetal Alchemist Tome 23"
+    [GeneratedRegex(@"^(.+?)\s+tome\s+(\d+)", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex SpaceTomePattern();
+
     // "Soda, vol. 1" or "Soda, vol 1"
     [GeneratedRegex(@"^(.+?),\s*vol\.?\s*(\d+)", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 1000)]
     private static partial Regex CommaVolPattern();
@@ -153,6 +189,7 @@ public partial class ComicSearchService : IComicSearchService
         {
             CommaTomePattern,
             DashTomePattern,
+            SpaceTomePattern,
             CommaVolPattern,
             DashVolPattern,
             SpaceVolPattern,

--- a/Application/ComicInfoSearch/ComicSearchService.cs
+++ b/Application/ComicInfoSearch/ComicSearchService.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
+using Application.Helpers;
 using Application.Interfaces;
 using Microsoft.Extensions.Options;
 
@@ -44,22 +45,22 @@ public partial class ComicSearchService : IComicSearchService
             {
                 Log.Information("Book found via OpenLibrary for ISBN {Isbn}", cleanIsbn);
                 return await MapBookResultToComicSearchResultAsync(
-                    result, isbn, cancellationToken);
+                    result, cleanIsbn, cancellationToken);
             }
 
             // Fallback to Google Books
             Log.Information("OpenLibrary returned no result for ISBN {Isbn}, trying Google Books", cleanIsbn);
-            var googleResult = await _googleBooksService.SearchByIsbnAsync(isbn, cancellationToken);
+            var googleResult = await _googleBooksService.SearchByIsbnAsync(cleanIsbn, cancellationToken);
 
             if (googleResult.Found)
             {
                 Log.Information("Book found via Google Books for ISBN {Isbn}", cleanIsbn);
                 return await MapBookResultToComicSearchResultAsync(
-                    googleResult, isbn, cancellationToken);
+                    googleResult, cleanIsbn, cancellationToken);
             }
 
             Log.Warning("No data found for ISBN {Isbn} in any provider", cleanIsbn);
-            return CreateNotFoundResult(isbn);
+            return CreateNotFoundResult(cleanIsbn);
         }
         catch (HttpRequestException ex)
         {
@@ -123,8 +124,7 @@ public partial class ComicSearchService : IComicSearchService
 
     private async Task<string> UploadCoverToCloudinaryAsync(Uri coverUrl, string isbn, CancellationToken cancellationToken)
     {
-        var cleanIsbn = isbn.Replace("-", "", StringComparison.Ordinal)
-                           .Replace(" ", "", StringComparison.Ordinal);
+        var cleanIsbn = IsbnHelper.NormalizeIsbn(isbn);
 
         var uploadResult = await _cloudinaryService.UploadImageFromUrlAsync(
             coverUrl,

--- a/Application/ComicInfoSearch/ComicSearchService.cs
+++ b/Application/ComicInfoSearch/ComicSearchService.cs
@@ -28,14 +28,21 @@ public partial class ComicSearchService : IComicSearchService
 
     public async Task<ComicSearchResult> SearchByIsbnAsync(string isbn, CancellationToken cancellationToken = default)
     {
+
+        var cleanIsbn = isbn.Replace("-", "", StringComparison.Ordinal)
+                               .Replace(" ", "", StringComparison.Ordinal)
+                               .Trim();
+
         try
         {
+            
+
             // Try OpenLibrary first
-            var result = await _openLibraryService.SearchByIsbnAsync(isbn, cancellationToken);
+            var result = await _openLibraryService.SearchByIsbnAsync(cleanIsbn, cancellationToken);
 
             if (result.Found)
             {
-                Log.Information("Book found via OpenLibrary for ISBN {Isbn}", isbn);
+                Log.Information("Book found via OpenLibrary for ISBN {Isbn}", cleanIsbn);
                 return await MapBookResultToComicSearchResultAsync(
                     result.Title, result.Subtitle, result.Authors, result.Publishers,
                     result.PublishDate, result.NumberOfPages, result.CoverUrl,
@@ -43,40 +50,40 @@ public partial class ComicSearchService : IComicSearchService
             }
 
             // Fallback to Google Books
-            Log.Information("OpenLibrary returned no result for ISBN {Isbn}, trying Google Books", isbn);
+            Log.Information("OpenLibrary returned no result for ISBN {Isbn}, trying Google Books", cleanIsbn);
             var googleResult = await _googleBooksService.SearchByIsbnAsync(isbn, cancellationToken);
 
             if (googleResult.Found)
             {
-                Log.Information("Book found via Google Books for ISBN {Isbn}", isbn);
+                Log.Information("Book found via Google Books for ISBN {Isbn}", cleanIsbn);
                 return await MapBookResultToComicSearchResultAsync(
                     googleResult.Title, googleResult.Subtitle, googleResult.Authors, googleResult.Publishers,
                     googleResult.PublishDate, googleResult.NumberOfPages, googleResult.CoverUrl,
                     isbn, cancellationToken);
             }
 
-            Log.Warning("No data found for ISBN {Isbn} in any provider", isbn);
+            Log.Warning("No data found for ISBN {Isbn} in any provider", cleanIsbn);
             return CreateNotFoundResult(isbn);
         }
         catch (HttpRequestException ex)
         {
-            Log.Error(ex, "HTTP error searching for ISBN {Isbn}", isbn);
-            return CreateNotFoundResult(isbn);
+            Log.Error(ex, "HTTP error searching for ISBN {Isbn}", cleanIsbn);
+            return CreateNotFoundResult(cleanIsbn);
         }
         catch (InvalidOperationException ex)
         {
-            Log.Error(ex, "Invalid operation searching for ISBN {Isbn}", isbn);
-            return CreateNotFoundResult(isbn);
+            Log.Error(ex, "Invalid operation searching for ISBN {Isbn}", cleanIsbn);
+            return CreateNotFoundResult(cleanIsbn);
         }
         catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
         {
-            Log.Error(ex, "Timeout searching for ISBN {Isbn}", isbn);
-            return CreateNotFoundResult(isbn);
+            Log.Error(ex, "Timeout searching for ISBN {Isbn}", cleanIsbn);
+            return CreateNotFoundResult(cleanIsbn);
         }
         catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
         {
-            Log.Warning(ex, "Search cancelled for ISBN {Isbn}", isbn);
-            return CreateNotFoundResult(isbn);
+            Log.Warning(ex, "Search cancelled for ISBN {Isbn}", cleanIsbn);
+            return CreateNotFoundResult(cleanIsbn);
         }
     }
 

--- a/Application/ComicInfoSearch/ComicSearchService.cs
+++ b/Application/ComicInfoSearch/ComicSearchService.cs
@@ -44,9 +44,7 @@ public partial class ComicSearchService : IComicSearchService
             {
                 Log.Information("Book found via OpenLibrary for ISBN {Isbn}", cleanIsbn);
                 return await MapBookResultToComicSearchResultAsync(
-                    result.Title, result.Subtitle, result.Authors, result.Publishers,
-                    result.PublishDate, result.NumberOfPages, result.CoverUrl,
-                    isbn, cancellationToken);
+                    result, isbn, cancellationToken);
             }
 
             // Fallback to Google Books
@@ -57,9 +55,7 @@ public partial class ComicSearchService : IComicSearchService
             {
                 Log.Information("Book found via Google Books for ISBN {Isbn}", cleanIsbn);
                 return await MapBookResultToComicSearchResultAsync(
-                    googleResult.Title, googleResult.Subtitle, googleResult.Authors, googleResult.Publishers,
-                    googleResult.PublishDate, googleResult.NumberOfPages, googleResult.CoverUrl,
-                    isbn, cancellationToken);
+                    googleResult, isbn, cancellationToken);
             }
 
             Log.Warning("No data found for ISBN {Isbn} in any provider", cleanIsbn);
@@ -88,32 +84,26 @@ public partial class ComicSearchService : IComicSearchService
     }
 
     private async Task<ComicSearchResult> MapBookResultToComicSearchResultAsync(
-        string resultTitle,
-        string? subtitle,
-        IReadOnlyList<string> resultAuthors,
-        IReadOnlyList<string> resultPublishers,
-        string? publishDateString,
-        int? numberOfPages,
-        Uri? coverUrl,
+        IBookSearchResult bookResult,
         string isbn,
         CancellationToken cancellationToken)
     {
-        var (serie, volumeNumber) = ParseVolumeAndSerie(resultTitle);
+        var (serie, volumeNumber) = ParseVolumeAndSerie(bookResult.Title);
 
         // If subtitle exists, use it as title; otherwise use series name
         // This strips volume info from the title (e.g. "Fullmetal Alchemist Tome 23" → "Fullmetal Alchemist")
-        var title = string.IsNullOrEmpty(subtitle) ? serie : subtitle;
+        var title = string.IsNullOrEmpty(bookResult.Subtitle) ? serie : bookResult.Subtitle;
 
         // Upload cover to Cloudinary if available
         var imageUrl = string.Empty;
-        if (coverUrl != null)
+        if (bookResult.CoverUrl != null)
         {
-            imageUrl = await UploadCoverToCloudinaryAsync(coverUrl, isbn, cancellationToken);
+            imageUrl = await UploadCoverToCloudinaryAsync(bookResult.CoverUrl, isbn, cancellationToken);
         }
 
-        var authors = string.Join(", ", resultAuthors);
-        var publishers = string.Join(", ", resultPublishers);
-        var publishDate = ParsePublishDate(publishDateString);
+        var authors = string.Join(", ", bookResult.Authors);
+        var publishers = string.Join(", ", bookResult.Publishers);
+        var publishDate = ParsePublishDate(bookResult.PublishDate);
 
         Log.Information("Found book: {Title} - {Serie} Vol.{Volume}", title, serie, volumeNumber);
 
@@ -126,7 +116,7 @@ public partial class ComicSearchService : IComicSearchService
             Authors: authors,
             Publishers: publishers,
             PublishDate: publishDate,
-            NumberOfPages: numberOfPages,
+            NumberOfPages: bookResult.NumberOfPages,
             Found: true
         );
     }

--- a/Application/ComicInfoSearch/GoogleBooksService.cs
+++ b/Application/ComicInfoSearch/GoogleBooksService.cs
@@ -19,11 +19,13 @@ public class GoogleBooksService : IGoogleBooksService
 
     public async Task<GoogleBooksBookResult> SearchByIsbnAsync(string isbn, CancellationToken cancellationToken = default)
     {
-        try
-        {
-            var cleanIsbn = isbn.Replace("-", "", StringComparison.Ordinal)
+        var cleanIsbn = isbn.Replace("-", "", StringComparison.Ordinal)
                                .Replace(" ", "", StringComparison.Ordinal)
                                .Trim();
+
+        try
+        {
+            
             var url = new Uri($"{BaseUrl}/volumes?q=isbn:{cleanIsbn}");
 
             Log.Information("Searching Google Books for ISBN: {Isbn}", cleanIsbn);
@@ -83,17 +85,17 @@ public class GoogleBooksService : IGoogleBooksService
         }
         catch (HttpRequestException ex)
         {
-            Log.Error(ex, "HTTP error searching Google Books for ISBN: {Isbn}", isbn);
+            Log.Error(ex, "HTTP error searching Google Books for ISBN: {Isbn}", cleanIsbn);
             return CreateNotFoundResult();
         }
         catch (JsonException ex)
         {
-            Log.Error(ex, "JSON parsing error for ISBN: {Isbn}", isbn);
+            Log.Error(ex, "JSON parsing error for ISBN: {Isbn}", cleanIsbn);
             return CreateNotFoundResult();
         }
         catch (TaskCanceledException ex) when (ex.CancellationToken != cancellationToken)
         {
-            Log.Error(ex, "Timeout searching Google Books for ISBN: {Isbn}", isbn);
+            Log.Error(ex, "Timeout searching Google Books for ISBN: {Isbn}", cleanIsbn);
             return CreateNotFoundResult();
         }
     }

--- a/Application/ComicInfoSearch/GoogleBooksService.cs
+++ b/Application/ComicInfoSearch/GoogleBooksService.cs
@@ -1,0 +1,214 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Application.Interfaces;
+
+namespace Application.ComicInfoSearch;
+
+public class GoogleBooksService : IGoogleBooksService
+{
+    private static Serilog.ILogger Log => Serilog.Log.ForContext<GoogleBooksService>();
+
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://www.googleapis.com/books/v1";
+
+    public GoogleBooksService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<GoogleBooksBookResult> SearchByIsbnAsync(string isbn, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var cleanIsbn = isbn.Replace("-", "", StringComparison.Ordinal)
+                               .Replace(" ", "", StringComparison.Ordinal)
+                               .Trim();
+            var url = new Uri($"{BaseUrl}/volumes?q=isbn:{cleanIsbn}");
+
+            Log.Information("Searching Google Books for ISBN: {Isbn}", cleanIsbn);
+
+            var response = await _httpClient.GetAsync(url, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                Log.Warning("Google Books returned {StatusCode} for ISBN: {Isbn}", response.StatusCode, cleanIsbn);
+                return CreateNotFoundResult();
+            }
+
+            var searchResponse = await response.Content.ReadFromJsonAsync<GoogleBooksSearchResponse>(
+                JsonOptions, cancellationToken);
+
+            if (searchResponse?.Items is null || searchResponse.Items.Count == 0)
+            {
+                Log.Warning("No items found in Google Books for ISBN: {Isbn}", cleanIsbn);
+                return CreateNotFoundResult();
+            }
+
+            // Fetch detailed volume info via selfLink for complete metadata
+            // The search endpoint often returns truncated titles (e.g. "Fullmetal Alchemist" instead of "Fullmetal Alchemist Tome 23")
+            var volumeInfo = await GetDetailedVolumeInfoAsync(searchResponse.Items[0], cancellationToken);
+
+            if (volumeInfo is null)
+            {
+                Log.Warning("No volumeInfo in Google Books response for ISBN: {Isbn}", cleanIsbn);
+                return CreateNotFoundResult();
+            }
+
+            // Build cover URL - prefer the largest available image
+            var coverUrl = GetBestCoverUrl(volumeInfo.ImageLinks);
+
+            // Publisher is a single string in Google Books, wrap it in a list
+            var publishers = string.IsNullOrEmpty(volumeInfo.Publisher)
+                ? (IReadOnlyList<string>)[]
+                : [volumeInfo.Publisher];
+
+            Log.Information("Found book: {Title} by {Authors}",
+                volumeInfo.Title,
+                string.Join(", ", volumeInfo.Authors ?? []));
+
+            return new GoogleBooksBookResult(
+                Title: volumeInfo.Title ?? string.Empty,
+                Subtitle: volumeInfo.Subtitle,
+                Authors: volumeInfo.Authors ?? [],
+                Publishers: publishers,
+                PublishDate: volumeInfo.PublishedDate,
+                NumberOfPages: volumeInfo.PageCount,
+                CoverUrl: coverUrl,
+                Description: volumeInfo.Description,
+                Categories: volumeInfo.Categories ?? [],
+                Language: volumeInfo.Language,
+                Found: true
+            );
+        }
+        catch (HttpRequestException ex)
+        {
+            Log.Error(ex, "HTTP error searching Google Books for ISBN: {Isbn}", isbn);
+            return CreateNotFoundResult();
+        }
+        catch (JsonException ex)
+        {
+            Log.Error(ex, "JSON parsing error for ISBN: {Isbn}", isbn);
+            return CreateNotFoundResult();
+        }
+        catch (TaskCanceledException ex) when (ex.CancellationToken != cancellationToken)
+        {
+            Log.Error(ex, "Timeout searching Google Books for ISBN: {Isbn}", isbn);
+            return CreateNotFoundResult();
+        }
+    }
+
+    private async Task<GoogleBooksVolumeInfo?> GetDetailedVolumeInfoAsync(
+        GoogleBooksVolume searchVolume,
+        CancellationToken cancellationToken)
+    {
+        if (searchVolume.SelfLink is not null)
+        {
+            try
+            {
+                Log.Information("Fetching detailed volume info from: {SelfLink}", searchVolume.SelfLink);
+                var detailedVolume = await _httpClient.GetFromJsonAsync<GoogleBooksVolume>(
+                    searchVolume.SelfLink, JsonOptions, cancellationToken);
+
+                if (detailedVolume?.VolumeInfo is not null)
+                {
+                    return detailedVolume.VolumeInfo;
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                Log.Warning(ex, "Failed to fetch detailed volume info, using search result data");
+            }
+            catch (JsonException ex)
+            {
+                Log.Warning(ex, "Failed to parse detailed volume info, using search result data");
+            }
+            catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                Log.Warning(ex, "Timeout fetching detailed volume info, using search result data");
+            }
+        }
+
+        // Fallback to search result data
+        return searchVolume.VolumeInfo;
+    }
+
+    private static Uri? GetBestCoverUrl(GoogleBooksImageLinks? imageLinks)
+    {
+        if (imageLinks is null)
+        {
+            return null;
+        }
+
+        // Prefer the largest available image
+        var url = imageLinks.ExtraLarge
+            ?? imageLinks.Large
+            ?? imageLinks.Medium
+            ?? imageLinks.Thumbnail
+            ?? imageLinks.SmallThumbnail;
+
+        if (string.IsNullOrEmpty(url))
+        {
+            return null;
+        }
+
+        // Google Books returns HTTP URLs; upgrade to HTTPS and remove edge=curl for clean images
+        url = url.Replace("http://", "https://", StringComparison.OrdinalIgnoreCase)
+                 .Replace("&edge=curl", "", StringComparison.OrdinalIgnoreCase);
+
+        return new Uri(url);
+    }
+
+    private static GoogleBooksBookResult CreateNotFoundResult() =>
+        new(
+            Title: string.Empty,
+            Subtitle: null,
+            Authors: [],
+            Publishers: [],
+            PublishDate: null,
+            NumberOfPages: null,
+            CoverUrl: null,
+            Description: null,
+            Categories: [],
+            Language: null,
+            Found: false
+        );
+
+    private static JsonSerializerOptions JsonOptions => new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    // Internal DTOs for JSON deserialization
+    private sealed record GoogleBooksSearchResponse(
+        [property: JsonPropertyName("totalItems")] int TotalItems,
+        [property: JsonPropertyName("items")] IReadOnlyList<GoogleBooksVolume>? Items
+    );
+
+    private sealed record GoogleBooksVolume(
+        [property: JsonPropertyName("selfLink")] string? SelfLink,
+        [property: JsonPropertyName("volumeInfo")] GoogleBooksVolumeInfo? VolumeInfo
+    );
+
+    private sealed record GoogleBooksVolumeInfo(
+        [property: JsonPropertyName("title")] string? Title,
+        [property: JsonPropertyName("subtitle")] string? Subtitle,
+        [property: JsonPropertyName("authors")] IReadOnlyList<string>? Authors,
+        [property: JsonPropertyName("publisher")] string? Publisher,
+        [property: JsonPropertyName("publishedDate")] string? PublishedDate,
+        [property: JsonPropertyName("description")] string? Description,
+        [property: JsonPropertyName("pageCount")] int? PageCount,
+        [property: JsonPropertyName("categories")] IReadOnlyList<string>? Categories,
+        [property: JsonPropertyName("imageLinks")] GoogleBooksImageLinks? ImageLinks,
+        [property: JsonPropertyName("language")] string? Language
+    );
+
+    private sealed record GoogleBooksImageLinks(
+        [property: JsonPropertyName("smallThumbnail")] string? SmallThumbnail,
+        [property: JsonPropertyName("thumbnail")] string? Thumbnail,
+        [property: JsonPropertyName("small")] string? Small,
+        [property: JsonPropertyName("medium")] string? Medium,
+        [property: JsonPropertyName("large")] string? Large,
+        [property: JsonPropertyName("extraLarge")] string? ExtraLarge
+    );
+}

--- a/Application/ComicInfoSearch/GoogleBooksService.cs
+++ b/Application/ComicInfoSearch/GoogleBooksService.cs
@@ -96,7 +96,7 @@ public class GoogleBooksService : IGoogleBooksService
             Log.Error(ex, "JSON parsing error for ISBN: {Isbn}", cleanIsbn);
             return CreateNotFoundResult();
         }
-        catch (TaskCanceledException ex) when (ex.CancellationToken != cancellationToken)
+        catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
         {
             Log.Error(ex, "Timeout searching Google Books for ISBN: {Isbn}", cleanIsbn);
             return CreateNotFoundResult();

--- a/Application/ComicInfoSearch/GoogleBooksService.cs
+++ b/Application/ComicInfoSearch/GoogleBooksService.cs
@@ -11,6 +11,7 @@ public class GoogleBooksService : IGoogleBooksService
 
     private readonly HttpClient _httpClient;
     private const string BaseUrl = "https://www.googleapis.com/books/v1";
+    private const string WebServiceUrl = $"{BaseUrl}/volumes?q=isbn:";
 
     public GoogleBooksService(HttpClient httpClient)
     {
@@ -26,7 +27,7 @@ public class GoogleBooksService : IGoogleBooksService
         try
         {
             
-            var url = new Uri($"{BaseUrl}/volumes?q=isbn:{cleanIsbn}");
+            var url = new Uri(WebServiceUrl + $"{cleanIsbn}");
 
             Log.Information("Searching Google Books for ISBN: {Isbn}", cleanIsbn);
 
@@ -146,6 +147,7 @@ public class GoogleBooksService : IGoogleBooksService
         var url = imageLinks.ExtraLarge
             ?? imageLinks.Large
             ?? imageLinks.Medium
+            ?? imageLinks.Small
             ?? imageLinks.Thumbnail
             ?? imageLinks.SmallThumbnail;
 
@@ -154,11 +156,28 @@ public class GoogleBooksService : IGoogleBooksService
             return null;
         }
 
-        // Google Books returns HTTP URLs; upgrade to HTTPS and remove edge=curl for clean images
-        url = url.Replace("http://", "https://", StringComparison.OrdinalIgnoreCase)
-                 .Replace("&edge=curl", "", StringComparison.OrdinalIgnoreCase);
+        // Parse the URL, force HTTPS, and strip the "edge" query parameter to get clean images
+        var builder = new UriBuilder(url)
+        {
+            Scheme = Uri.UriSchemeHttps,
+            Port = -1
+        };
 
-        return new Uri(url);
+        var rawQuery = builder.Query.TrimStart('?');
+        if (!string.IsNullOrEmpty(rawQuery))
+        {
+            var filtered = rawQuery
+                .Split('&', StringSplitOptions.RemoveEmptyEntries)
+                .Where(static param =>
+                {
+                    var eqIdx = param.IndexOf('=', StringComparison.Ordinal);
+                    var key = eqIdx >= 0 ? param[..eqIdx] : param;
+                    return !key.Equals("edge", StringComparison.OrdinalIgnoreCase);
+                });
+            builder.Query = string.Join("&", filtered);
+        }
+
+        return new Uri(builder.ToString());
     }
 
     private static GoogleBooksBookResult CreateNotFoundResult() =>

--- a/Application/ComicInfoSearch/GoogleBooksService.cs
+++ b/Application/ComicInfoSearch/GoogleBooksService.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Application.Interfaces;
+using Microsoft.Extensions.Options;
 
 namespace Application.ComicInfoSearch;
 
@@ -10,12 +11,13 @@ public class GoogleBooksService : IGoogleBooksService
     private static Serilog.ILogger Log => Serilog.Log.ForContext<GoogleBooksService>();
 
     private readonly HttpClient _httpClient;
-    private const string BaseUrl = "https://www.googleapis.com/books/v1";
-    private const string WebServiceUrl = $"{BaseUrl}/volumes?q=isbn:";
+    private const string SearchPath = "/volumes?q=isbn:";
+    private readonly GoogleBooksSettings _settings;
 
-    public GoogleBooksService(HttpClient httpClient)
+    public GoogleBooksService(HttpClient httpClient, IOptions<GoogleBooksSettings> settings)
     {
         _httpClient = httpClient;
+        _settings = settings.Value;
     }
 
     public async Task<GoogleBooksBookResult> SearchByIsbnAsync(string isbn, CancellationToken cancellationToken = default)
@@ -27,7 +29,7 @@ public class GoogleBooksService : IGoogleBooksService
         try
         {
             
-            var url = new Uri(WebServiceUrl + $"{cleanIsbn}");
+            var url = new Uri(_settings.BaseUrl + SearchPath + cleanIsbn);
 
             Log.Information("Searching Google Books for ISBN: {Isbn}", cleanIsbn);
 

--- a/Application/ComicInfoSearch/GoogleBooksSettings.cs
+++ b/Application/ComicInfoSearch/GoogleBooksSettings.cs
@@ -1,0 +1,6 @@
+namespace Application.ComicInfoSearch;
+
+public class GoogleBooksSettings
+{
+    public string BaseUrl { get; set; } = string.Empty;
+}

--- a/Application/ComicInfoSearch/GoogleBooksSettings.cs
+++ b/Application/ComicInfoSearch/GoogleBooksSettings.cs
@@ -2,5 +2,5 @@ namespace Application.ComicInfoSearch;
 
 public class GoogleBooksSettings
 {
-    public string BaseUrl { get; set; } = string.Empty;
+    public Uri? BaseUrl { get; set; } 
 }

--- a/Application/ComicInfoSearch/OpenLibraryService.cs
+++ b/Application/ComicInfoSearch/OpenLibraryService.cs
@@ -20,11 +20,13 @@ public class OpenLibraryService : IOpenLibraryService
 
     public async Task<OpenLibraryBookResult> SearchByIsbnAsync(string isbn, CancellationToken cancellationToken = default)
     {
-        try
-        {
-            var cleanIsbn = isbn.Replace("-", "", StringComparison.Ordinal)
+        var cleanIsbn = isbn.Replace("-", "", StringComparison.Ordinal)
                                .Replace(" ", "", StringComparison.Ordinal)
                                .Trim();
+
+        try
+        {
+            
             var url = new Uri($"{BaseUrl}/isbn/{cleanIsbn}.json");
 
             Log.Information("Searching OpenLibrary for ISBN: {Isbn}", cleanIsbn);
@@ -71,17 +73,17 @@ public class OpenLibraryService : IOpenLibraryService
         }
         catch (HttpRequestException ex)
         {
-            Log.Error(ex, "HTTP error searching OpenLibrary for ISBN: {Isbn}", isbn);
+            Log.Error(ex, "HTTP error searching OpenLibrary for ISBN: {Isbn}", cleanIsbn);
             return CreateNotFoundResult();
         }
         catch (JsonException ex)
         {
-            Log.Error(ex, "JSON parsing error for ISBN: {Isbn}", isbn);
+            Log.Error(ex, "JSON parsing error for ISBN: {Isbn}", cleanIsbn);
             return CreateNotFoundResult();
         }
         catch (TaskCanceledException ex) when (ex.CancellationToken != cancellationToken)
         {
-            Log.Error(ex, "Timeout searching OpenLibrary for ISBN: {Isbn}", isbn);
+            Log.Error(ex, "Timeout searching OpenLibrary for ISBN: {Isbn}", cleanIsbn);
             return CreateNotFoundResult();
         }
     }

--- a/Application/ComicInfoSearch/OpenLibraryService.cs
+++ b/Application/ComicInfoSearch/OpenLibraryService.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Application.Helpers;
 using Application.Interfaces;
 
 namespace Application.ComicInfoSearch;
@@ -20,9 +21,7 @@ public class OpenLibraryService : IOpenLibraryService
 
     public async Task<OpenLibraryBookResult> SearchByIsbnAsync(string isbn, CancellationToken cancellationToken = default)
     {
-        var cleanIsbn = isbn.Replace("-", "", StringComparison.Ordinal)
-                               .Replace(" ", "", StringComparison.Ordinal)
-                               .Trim();
+        var cleanIsbn = IsbnHelper.NormalizeIsbn(isbn);
 
         try
         {

--- a/Application/Helpers/IsbnHelper.cs
+++ b/Application/Helpers/IsbnHelper.cs
@@ -107,6 +107,8 @@ public static class IsbnHelper
         }
         return isbn.Replace("-", "", StringComparison.Ordinal)
                    .Replace(" ", "", StringComparison.Ordinal)
+                   .Replace(Environment.NewLine, "", StringComparison.Ordinal)
+                   .Trim()
                    .ToUpperInvariant();
     }
 }

--- a/Application/Interfaces/IBookSearchResult.cs
+++ b/Application/Interfaces/IBookSearchResult.cs
@@ -1,0 +1,13 @@
+namespace Application.Interfaces;
+
+public interface IBookSearchResult
+{
+    string Title { get; }
+    string? Subtitle { get; }
+    IReadOnlyList<string> Authors { get; }
+    IReadOnlyList<string> Publishers { get; }
+    string? PublishDate { get; }
+    int? NumberOfPages { get; }
+    Uri? CoverUrl { get; }
+    bool Found { get; }
+}

--- a/Application/Interfaces/IGoogleBooksService.cs
+++ b/Application/Interfaces/IGoogleBooksService.cs
@@ -12,7 +12,7 @@ public record GoogleBooksBookResult(
     IReadOnlyList<string> Categories,
     string? Language,
     bool Found
-);
+) : IBookSearchResult;
 
 public interface IGoogleBooksService
 {

--- a/Application/Interfaces/IGoogleBooksService.cs
+++ b/Application/Interfaces/IGoogleBooksService.cs
@@ -1,0 +1,20 @@
+namespace Application.Interfaces;
+
+public record GoogleBooksBookResult(
+    string Title,
+    string? Subtitle,
+    IReadOnlyList<string> Authors,
+    IReadOnlyList<string> Publishers,
+    string? PublishDate,
+    int? NumberOfPages,
+    Uri? CoverUrl,
+    string? Description,
+    IReadOnlyList<string> Categories,
+    string? Language,
+    bool Found
+);
+
+public interface IGoogleBooksService
+{
+    Task<GoogleBooksBookResult> SearchByIsbnAsync(string isbn, CancellationToken cancellationToken = default);
+}

--- a/Application/Interfaces/IOpenLibraryService.cs
+++ b/Application/Interfaces/IOpenLibraryService.cs
@@ -9,7 +9,7 @@ public record OpenLibraryBookResult(
     int? NumberOfPages,
     Uri? CoverUrl,
     bool Found
-);
+) : IBookSearchResult;
 
 public interface IOpenLibraryService
 {

--- a/Web/Components/Pages/Books/AddBookForm.razor
+++ b/Web/Components/Pages/Books/AddBookForm.razor
@@ -2,6 +2,7 @@
 @rendermode InteractiveServer
 
 @using Application.ComicInfoSearch
+@using Application.Helpers
 @using Application.Interfaces
 @using Microsoft.AspNetCore.Components
 @using Web.Services
@@ -125,9 +126,10 @@
             _isLoading = true;
             StateHasChanged();
 
+            string cleanedIsbn = IsbnHelper.NormalizeIsbn(Isbn);
+
             try
-            {
-                string cleanedIsbn = Isbn.Replace(Environment.NewLine, "").Trim();
+            {                
                 _searchResult = await ComicSearchService.SearchByIsbnAsync(cleanedIsbn);
 
                 if (_searchResult.Found)
@@ -151,7 +153,7 @@
                 {
                     _bookModel = new BookUiDto
                     {
-                        ISBN = Isbn,
+                        ISBN = cleanedIsbn,
                         VolumeNumber = 1
                     };
                     Snackbar.Add("Book not found. Please fill in the details manually.", Severity.Warning);
@@ -161,7 +163,7 @@
             {
                 _bookModel = new BookUiDto
                 {
-                    ISBN = Isbn,
+                    ISBN = cleanedIsbn,
                     VolumeNumber = 1
                 };
                 Snackbar.Add($"Error searching for book: {ex.Message}", Severity.Error);

--- a/Web/Components/Pages/Books/AddBookForm.razor
+++ b/Web/Components/Pages/Books/AddBookForm.razor
@@ -127,7 +127,8 @@
 
             try
             {
-                _searchResult = await ComicSearchService.SearchByIsbnAsync(Isbn);
+                string cleanedIsbn = Isbn.Replace(Environment.NewLine, "").Trim();
+                _searchResult = await ComicSearchService.SearchByIsbnAsync(cleanedIsbn);
 
                 if (_searchResult.Found)
                 {

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -51,6 +51,13 @@ builder.Services.AddHttpClient<IOpenLibraryService, OpenLibraryService>(client =
     client.Timeout = TimeSpan.FromSeconds(30);
 });
 
+// Config Google Books settings
+var googleBooksSection = configuration.GetSection("GoogleBooks");
+builder.Services.AddOptions<GoogleBooksSettings>()
+    .Bind(googleBooksSection)
+    .Validate(cfg => !string.IsNullOrWhiteSpace(cfg.BaseUrl), "GoogleBooks:BaseUrl is required")
+    .ValidateOnStart();
+
 // Config Google Books service for ISBN lookup (fallback)
 builder.Services.AddHttpClient<IGoogleBooksService, GoogleBooksService>(client =>
 {

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -51,6 +51,13 @@ builder.Services.AddHttpClient<IOpenLibraryService, OpenLibraryService>(client =
     client.Timeout = TimeSpan.FromSeconds(30);
 });
 
+// Config Google Books service for ISBN lookup (fallback)
+builder.Services.AddHttpClient<IGoogleBooksService, GoogleBooksService>(client =>
+{
+    client.DefaultRequestHeaders.Add("User-Agent", "MyComicsManager/1.0 (https://github.com/slucky31/mycomicsmanager)");
+    client.Timeout = TimeSpan.FromSeconds(30);
+});
+
 builder.Services
     .AddApplication()
     .AddInfrastructure(connectionString, configuration["LocalStorage:RootPath"]!, configuration);

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -55,7 +55,7 @@ builder.Services.AddHttpClient<IOpenLibraryService, OpenLibraryService>(client =
 var googleBooksSection = configuration.GetSection("GoogleBooks");
 builder.Services.AddOptions<GoogleBooksSettings>()
     .Bind(googleBooksSection)
-    .Validate(cfg => !string.IsNullOrWhiteSpace(cfg.BaseUrl), "GoogleBooks:BaseUrl is required")
+    .Validate(cfg => cfg.BaseUrl is not null, "GoogleBooks:BaseUrl is required")
     .ValidateOnStart();
 
 // Config Google Books service for ISBN lookup (fallback)

--- a/Web/appsettings.json
+++ b/Web/appsettings.json
@@ -42,6 +42,9 @@
     "ApiKey": "apikey",
     "ApiSecret": "apisecret",
     "Folder": "folder"
+  },
+  "GoogleBooks": {
+    "BaseUrl": "https://www.googleapis.com/books/v1"
   }
 }
 

--- a/tests/Application.UnitTests/ComicInfoSearch/ComicSearchServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/ComicSearchServiceTests.cs
@@ -78,6 +78,7 @@ public sealed class ComicSearchServiceTests
         result.Title.Should().BeEmpty();
         result.Serie.Should().BeEmpty();
         result.VolumeNumber.Should().Be(1);
+        await _googleBooksService.Received(1).SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -176,7 +177,7 @@ public sealed class ComicSearchServiceTests
             Success: true,
             Error: null);
 
-        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+        _openLibraryService.SearchByIsbnAsync("9781234567890", Arg.Any<CancellationToken>())
             .Returns(openLibraryResult);
         _cloudinaryService.UploadImageFromUrlAsync(
                 coverUrl,
@@ -614,7 +615,7 @@ public sealed class ComicSearchServiceTests
             Success: true,
             Error: null);
 
-        _openLibraryService.SearchByIsbnAsync(isbnWithFormatting, Arg.Any<CancellationToken>())
+        _openLibraryService.SearchByIsbnAsync(expectedCleanIsbn, Arg.Any<CancellationToken>())
             .Returns(openLibraryResult);
         _cloudinaryService.UploadImageFromUrlAsync(
                 Arg.Any<Uri>(),

--- a/tests/Application.UnitTests/ComicInfoSearch/ComicSearchServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/ComicSearchServiceTests.cs
@@ -14,6 +14,7 @@ public sealed class ComicSearchServiceTests
     private static readonly string[] SinglePublisherArray = ["Publisher"];
 
     private readonly IOpenLibraryService _openLibraryService;
+    private readonly IGoogleBooksService _googleBooksService;
     private readonly ICloudinaryService _cloudinaryService;
     private readonly IOptions<CloudinarySettings> _cloudinarySettings;
     private readonly ComicSearchService _sut;
@@ -21,6 +22,7 @@ public sealed class ComicSearchServiceTests
     public ComicSearchServiceTests()
     {
         _openLibraryService = Substitute.For<IOpenLibraryService>();
+        _googleBooksService = Substitute.For<IGoogleBooksService>();
         _cloudinaryService = Substitute.For<ICloudinaryService>();
         _cloudinarySettings = Options.Create(new CloudinarySettings
         {
@@ -29,13 +31,13 @@ public sealed class ComicSearchServiceTests
             ApiSecret = "test-secret",
             Folder = "test-covers"
         });
-        _sut = new ComicSearchService(_openLibraryService, _cloudinaryService, _cloudinarySettings);
+        _sut = new ComicSearchService(_openLibraryService, _googleBooksService, _cloudinaryService, _cloudinarySettings);
     }
 
     #region SearchByIsbnAsync Tests
 
     [Fact]
-    public async Task SearchByIsbnAsync_ShouldReturnNotFound_WhenOpenLibraryReturnsNotFound()
+    public async Task SearchByIsbnAsync_ShouldReturnNotFound_WhenBothProvidersReturnNotFound()
     {
         // Arrange
         const string isbn = "9781234567890";
@@ -49,8 +51,23 @@ public sealed class ComicSearchServiceTests
             CoverUrl: null,
             Found: false);
 
+        var googleBooksResult = new GoogleBooksBookResult(
+            Title: string.Empty,
+            Subtitle: null,
+            Authors: EmptyStringArray,
+            Publishers: EmptyStringArray,
+            PublishDate: null,
+            NumberOfPages: null,
+            CoverUrl: null,
+            Description: null,
+            Categories: [],
+            Language: null,
+            Found: false);
+
         _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
             .Returns(openLibraryResult);
+        _googleBooksService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(googleBooksResult);
 
         // Act
         var result = await _sut.SearchByIsbnAsync(isbn);
@@ -100,7 +117,7 @@ public sealed class ComicSearchServiceTests
         // Assert
         result.Found.Should().BeTrue();
         result.Isbn.Should().Be(isbn);
-        result.Title.Should().Be(title);
+        result.Title.Should().Be("Soda");
         result.Serie.Should().Be("Soda");
         result.VolumeNumber.Should().Be(1);
         result.Authors.Should().Be("Philippe Tome, Luc Wartholz");
@@ -305,6 +322,8 @@ public sealed class ComicSearchServiceTests
     [InlineData("Soda, tome 12", "Soda", 12)]
     [InlineData("Tintin - tome 3", "Tintin", 3)]
     [InlineData("Asterix - tome 24", "Asterix", 24)]
+    [InlineData("Fullmetal Alchemist Tome 23", "Fullmetal Alchemist", 23)]
+    [InlineData("One Piece Tome 105", "One Piece", 105)]
     [InlineData("Spider-Man, vol. 5", "Spider-Man", 5)]
     [InlineData("Batman, vol 10", "Batman", 10)]
     [InlineData("Superman - vol. 2", "Superman", 2)]
@@ -476,6 +495,7 @@ public sealed class ComicSearchServiceTests
     [Theory]
     [InlineData("SODA, TOME 1", "SODA", 1)]
     [InlineData("soda, tome 5", "soda", 5)]
+    [InlineData("FULLMETAL ALCHEMIST TOME 23", "FULLMETAL ALCHEMIST", 23)]
     [InlineData("Spider-Man, VOL. 10", "Spider-Man", 10)]
     [InlineData("Batman #25", "Batman", 25)]
     public async Task SearchByIsbnAsync_ShouldParseVolumeAndSerie_CaseInsensitively(
@@ -973,6 +993,237 @@ public sealed class ComicSearchServiceTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             cancellationToken);
+    }
+
+    #endregion
+
+    #region Google Books Fallback Tests
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldFallbackToGoogleBooks_WhenOpenLibraryReturnsNotFound()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: string.Empty,
+            Subtitle: null,
+            Authors: EmptyStringArray,
+            Publishers: EmptyStringArray,
+            PublishDate: null,
+            NumberOfPages: null,
+            CoverUrl: null,
+            Found: false);
+
+        var googleBooksResult = new GoogleBooksBookResult(
+            Title: "Soda, tome 1",
+            Subtitle: "Prières et balistique",
+            Authors: ["Philippe Tome", "Luc Warnant"],
+            Publishers: ["Dupuis"],
+            PublishDate: "1987",
+            NumberOfPages: 48,
+            CoverUrl: new Uri("https://books.google.com/content?id=test"),
+            Description: "A comic book.",
+            Categories: ["Comics & Graphic Novels"],
+            Language: "fr",
+            Found: true);
+
+        var cloudinaryResult = new CloudinaryUploadResult(
+            Url: new Uri("https://res.cloudinary.com/test/image/upload/v1/test-covers/9781234567890.jpg"),
+            PublicId: "test-covers/9781234567890",
+            Success: true,
+            Error: null);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+        _googleBooksService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(googleBooksResult);
+        _cloudinaryService.UploadImageFromUrlAsync(
+                Arg.Any<Uri>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(cloudinaryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.Found.Should().BeTrue();
+        result.Isbn.Should().Be(isbn);
+        result.Title.Should().Be("Prières et balistique");
+        result.Serie.Should().Be("Soda");
+        result.VolumeNumber.Should().Be(1);
+        result.Authors.Should().Be("Philippe Tome, Luc Warnant");
+        result.Publishers.Should().Be("Dupuis");
+        result.NumberOfPages.Should().Be(48);
+        result.PublishDate.Should().Be(new DateOnly(1987, 1, 1));
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldNotCallGoogleBooks_WhenOpenLibraryReturnsData()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: "Test Comic",
+            Subtitle: null,
+            Authors: SingleAuthorArray,
+            Publishers: SinglePublisherArray,
+            PublishDate: "2024",
+            NumberOfPages: 100,
+            CoverUrl: null,
+            Found: true);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+
+        // Act
+        await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        await _googleBooksService.DidNotReceive().SearchByIsbnAsync(
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldUploadGoogleBooksCoverToCloudinary_WhenFallbackSucceeds()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: string.Empty, Subtitle: null, Authors: EmptyStringArray,
+            Publishers: EmptyStringArray, PublishDate: null, NumberOfPages: null,
+            CoverUrl: null, Found: false);
+
+        var googleCoverUrl = new Uri("https://books.google.com/content?id=test&img=1");
+        var googleBooksResult = new GoogleBooksBookResult(
+            Title: "Test Comic",
+            Subtitle: null,
+            Authors: SingleAuthorArray,
+            Publishers: SinglePublisherArray,
+            PublishDate: "2024",
+            NumberOfPages: 100,
+            CoverUrl: googleCoverUrl,
+            Description: null,
+            Categories: [],
+            Language: null,
+            Found: true);
+
+        var cloudinaryResult = new CloudinaryUploadResult(
+            Url: new Uri("https://res.cloudinary.com/test/uploaded.jpg"),
+            PublicId: "test-id",
+            Success: true,
+            Error: null);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+        _googleBooksService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(googleBooksResult);
+        _cloudinaryService.UploadImageFromUrlAsync(
+                googleCoverUrl,
+                "test-covers",
+                isbn,
+                Arg.Any<CancellationToken>())
+            .Returns(cloudinaryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.ImageUrl.Should().Be("https://res.cloudinary.com/test/uploaded.jpg");
+        await _cloudinaryService.Received(1).UploadImageFromUrlAsync(
+            googleCoverUrl,
+            "test-covers",
+            isbn,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldPassCancellationToken_ToGoogleBooksService()
+    {
+        // Arrange
+        const string isbn = "9781234567890";
+        using var cts = new CancellationTokenSource();
+        var cancellationToken = cts.Token;
+
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: string.Empty, Subtitle: null, Authors: EmptyStringArray,
+            Publishers: EmptyStringArray, PublishDate: null, NumberOfPages: null,
+            CoverUrl: null, Found: false);
+
+        var googleBooksResult = new GoogleBooksBookResult(
+            Title: "Test", Subtitle: null, Authors: EmptyStringArray,
+            Publishers: EmptyStringArray, PublishDate: null, NumberOfPages: null,
+            CoverUrl: null, Description: null, Categories: [], Language: null,
+            Found: true);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, cancellationToken)
+            .Returns(openLibraryResult);
+        _googleBooksService.SearchByIsbnAsync(isbn, cancellationToken)
+            .Returns(googleBooksResult);
+
+        // Act
+        await _sut.SearchByIsbnAsync(isbn, cancellationToken);
+
+        // Assert
+        await _googleBooksService.Received(1).SearchByIsbnAsync(isbn, cancellationToken);
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_ShouldMapGoogleBooksMetadata_WithAllFields()
+    {
+        // Arrange
+        const string isbn = "9781607066019";
+        var openLibraryResult = new OpenLibraryBookResult(
+            Title: string.Empty, Subtitle: null, Authors: EmptyStringArray,
+            Publishers: EmptyStringArray, PublishDate: null, NumberOfPages: null,
+            CoverUrl: null, Found: false);
+
+        var googleBooksResult = new GoogleBooksBookResult(
+            Title: "Saga, vol. 1",
+            Subtitle: "Chapter One",
+            Authors: ["Brian K. Vaughan", "Fiona Staples"],
+            Publishers: ["Image Comics"],
+            PublishDate: "2012-10-10",
+            NumberOfPages: 160,
+            CoverUrl: new Uri("https://books.google.com/content?id=test"),
+            Description: "An epic space opera.",
+            Categories: ["Comics & Graphic Novels"],
+            Language: "en",
+            Found: true);
+
+        var cloudinaryResult = new CloudinaryUploadResult(
+            Url: new Uri("https://res.cloudinary.com/test/saga.jpg"),
+            PublicId: "test-id",
+            Success: true,
+            Error: null);
+
+        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(openLibraryResult);
+        _googleBooksService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(googleBooksResult);
+        _cloudinaryService.UploadImageFromUrlAsync(
+                Arg.Any<Uri>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(cloudinaryResult);
+
+        // Act
+        var result = await _sut.SearchByIsbnAsync(isbn);
+
+        // Assert
+        result.Found.Should().BeTrue();
+        result.Isbn.Should().Be(isbn);
+        result.Title.Should().Be("Chapter One");
+        result.Serie.Should().Be("Saga");
+        result.VolumeNumber.Should().Be(1);
+        result.Authors.Should().Be("Brian K. Vaughan, Fiona Staples");
+        result.Publishers.Should().Be("Image Comics");
+        result.PublishDate.Should().Be(new DateOnly(2012, 10, 10));
+        result.NumberOfPages.Should().Be(160);
+        result.ImageUrl.Should().NotBeEmpty();
     }
 
     #endregion

--- a/tests/Application.UnitTests/ComicInfoSearch/GoogleBooksServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/GoogleBooksServiceTests.cs
@@ -3,7 +3,7 @@ using Application.ComicInfoSearch;
 
 namespace Application.UnitTests.ComicInfoSearch;
 
-public class GoogleBooksServiceTests
+public sealed class GoogleBooksServiceTests
 {
     private const string ValidIsbn = "9782205089165";
     private const string ValidIsbnWithDashes = "978-2-205-08916-5";

--- a/tests/Application.UnitTests/ComicInfoSearch/GoogleBooksServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/GoogleBooksServiceTests.cs
@@ -1,0 +1,627 @@
+using System.Net;
+using Application.ComicInfoSearch;
+
+namespace Application.UnitTests.ComicInfoSearch;
+
+public class GoogleBooksServiceTests
+{
+    private const string ValidIsbn = "9782205089165";
+    private const string ValidIsbnWithDashes = "978-2-205-08916-5";
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnBookResult_WhenBookFound()
+    {
+        // Arrange
+        var jsonResponse = """
+        {
+            "totalItems": 1,
+            "items": [{
+                "volumeInfo": {
+                    "title": "Le Jardin secret - Tome 1",
+                    "subtitle": "Le jardin de Gaston",
+                    "authors": ["Jim", "Pierre Brochard"],
+                    "publisher": "DARGAUD",
+                    "publishedDate": "2021-04-23",
+                    "description": "A beautiful comic about gardens.",
+                    "pageCount": 96,
+                    "categories": ["Comics & Graphic Novels"],
+                    "imageLinks": {
+                        "smallThumbnail": "http://books.google.com/small.jpg",
+                        "thumbnail": "http://books.google.com/thumb.jpg"
+                    },
+                    "language": "fr"
+                }
+            }]
+        }
+        """;
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(jsonResponse)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.Found.Should().BeTrue();
+        result.Title.Should().Be("Le Jardin secret - Tome 1");
+        result.Subtitle.Should().Be("Le jardin de Gaston");
+        result.Authors.Should().HaveCount(2);
+        result.Authors.Should().Contain("Jim");
+        result.Authors.Should().Contain("Pierre Brochard");
+        result.Publishers.Should().ContainSingle().Which.Should().Be("DARGAUD");
+        result.PublishDate.Should().Be("2021-04-23");
+        result.NumberOfPages.Should().Be(96);
+        result.Description.Should().Be("A beautiful comic about gardens.");
+        result.Categories.Should().ContainSingle().Which.Should().Be("Comics & Graphic Novels");
+        result.Language.Should().Be("fr");
+        result.CoverUrl.Should().NotBeNull();
+        result.CoverUrl!.ToString().Should().StartWith("https://");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_CleanIsbn_WhenIsbnContainsDashesAndSpaces()
+    {
+        // Arrange
+        var jsonResponse = """
+        {
+            "totalItems": 1,
+            "items": [{
+                "volumeInfo": {
+                    "title": "Test Book",
+                    "imageLinks": { "thumbnail": "http://books.google.com/thumb.jpg" }
+                }
+            }]
+        }
+        """;
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(jsonResponse)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbnWithDashes);
+
+        // Assert
+        result.Found.Should().BeTrue();
+        result.Title.Should().Be("Test Book");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenApiReturnsTotalItemsZero()
+    {
+        // Arrange
+        var jsonResponse = """{"totalItems": 0}""";
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(jsonResponse)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.Found.Should().BeFalse();
+        result.Title.Should().BeEmpty();
+        result.CoverUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenApiReturnsError()
+    {
+        // Arrange
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenHttpRequestFails()
+    {
+        // Arrange
+        using var handler = new MockHttpMessageHandler(
+            new HttpRequestException("Network error"));
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenJsonIsInvalid()
+    {
+        // Arrange
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse("invalid json {{{")
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnResultWithoutCover_WhenNoImageLinksInResponse()
+    {
+        // Arrange
+        var jsonResponse = """
+        {
+            "totalItems": 1,
+            "items": [{
+                "volumeInfo": {
+                    "title": "Book Without Cover",
+                    "publisher": "Publisher"
+                }
+            }]
+        }
+        """;
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(jsonResponse)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.Found.Should().BeTrue();
+        result.Title.Should().Be("Book Without Cover");
+        result.CoverUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnResultWithoutAuthors_WhenNoAuthorsInResponse()
+    {
+        // Arrange
+        var jsonResponse = """
+        {
+            "totalItems": 1,
+            "items": [{
+                "volumeInfo": {
+                    "title": "Book Without Authors"
+                }
+            }]
+        }
+        """;
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(jsonResponse)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.Found.Should().BeTrue();
+        result.Authors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnMultipleAuthors_WhenMultipleAuthorsInResponse()
+    {
+        // Arrange
+        var jsonResponse = """
+        {
+            "totalItems": 1,
+            "items": [{
+                "volumeInfo": {
+                    "title": "Multi-Author Book",
+                    "authors": ["Author One", "Author Two", "Author Three"]
+                }
+            }]
+        }
+        """;
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(jsonResponse)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.Found.Should().BeTrue();
+        result.Authors.Should().HaveCount(3);
+        result.Authors.Should().Contain("Author One");
+        result.Authors.Should().Contain("Author Two");
+        result.Authors.Should().Contain("Author Three");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_HandleCancellation()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse("{}")
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<TaskCanceledException>(
+            () => service.SearchByIsbnAsync(ValidIsbn, cts.Token));
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_PreferLargestImage_WhenMultipleImageSizesAvailable()
+    {
+        // Arrange
+        var jsonResponse = """
+        {
+            "totalItems": 1,
+            "items": [{
+                "volumeInfo": {
+                    "title": "Book With Images",
+                    "imageLinks": {
+                        "smallThumbnail": "http://books.google.com/small.jpg",
+                        "thumbnail": "http://books.google.com/thumb.jpg",
+                        "medium": "http://books.google.com/medium.jpg",
+                        "large": "http://books.google.com/large.jpg"
+                    }
+                }
+            }]
+        }
+        """;
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(jsonResponse)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.Found.Should().BeTrue();
+        result.CoverUrl.Should().NotBeNull();
+        result.CoverUrl!.ToString().Should().Contain("large");
+        result.CoverUrl.ToString().Should().StartWith("https://");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_UpgradeHttpToHttps_ForCoverUrl()
+    {
+        // Arrange
+        var jsonResponse = """
+        {
+            "totalItems": 1,
+            "items": [{
+                "volumeInfo": {
+                    "title": "Test",
+                    "imageLinks": {
+                        "thumbnail": "http://books.google.com/thumb.jpg&edge=curl"
+                    }
+                }
+            }]
+        }
+        """;
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(jsonResponse)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.CoverUrl.Should().NotBeNull();
+        result.CoverUrl!.ToString().Should().StartWith("https://");
+        result.CoverUrl.ToString().Should().NotContain("edge=curl");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_WrapSinglePublisher_InList()
+    {
+        // Arrange
+        var jsonResponse = """
+        {
+            "totalItems": 1,
+            "items": [{
+                "volumeInfo": {
+                    "title": "Test",
+                    "publisher": "DARGAUD"
+                }
+            }]
+        }
+        """;
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(jsonResponse)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.Found.Should().BeTrue();
+        result.Publishers.Should().ContainSingle().Which.Should().Be("DARGAUD");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnEmptyPublishers_WhenNoPublisherInResponse()
+    {
+        // Arrange
+        var jsonResponse = """
+        {
+            "totalItems": 1,
+            "items": [{
+                "volumeInfo": {
+                    "title": "Test"
+                }
+            }]
+        }
+        """;
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(jsonResponse)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.Found.Should().BeTrue();
+        result.Publishers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenVolumeInfoIsNull()
+    {
+        // Arrange
+        var jsonResponse = """
+        {
+            "totalItems": 1,
+            "items": [{}]
+        }
+        """;
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(jsonResponse)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnCategories_WhenCategoriesPresent()
+    {
+        // Arrange
+        var jsonResponse = """
+        {
+            "totalItems": 1,
+            "items": [{
+                "volumeInfo": {
+                    "title": "Test",
+                    "categories": ["Comics & Graphic Novels", "Fiction"]
+                }
+            }]
+        }
+        """;
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(jsonResponse)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.Found.Should().BeTrue();
+        result.Categories.Should().HaveCount(2);
+        result.Categories.Should().Contain("Comics & Graphic Novels");
+        result.Categories.Should().Contain("Fiction");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_UseDetailedVolumeInfo_WhenSelfLinkIsAvailable()
+    {
+        // Arrange
+        var searchResponse = """
+        {
+            "totalItems": 1,
+            "items": [{
+                "selfLink": "https://www.googleapis.com/books/v1/volumes/kOJlRgAACAAJ",
+                "volumeInfo": {
+                    "title": "Fullmetal Alchemist",
+                    "authors": ["Hiromu Arakawa"],
+                    "pageCount": 180,
+                    "language": "fr"
+                }
+            }]
+        }
+        """;
+
+        var detailedResponse = """
+        {
+            "selfLink": "https://www.googleapis.com/books/v1/volumes/kOJlRgAACAAJ",
+            "volumeInfo": {
+                "title": "Fullmetal Alchemist Tome 23",
+                "authors": ["Hiromu Arakawa"],
+                "publisher": "Kurokawa",
+                "publishedDate": "2010-04-08",
+                "pageCount": 176,
+                "language": "fr"
+            }
+        }
+        """;
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(searchResponse),
+            ["https://www.googleapis.com/books/v1/volumes/kOJlRgAACAAJ"] = CreateJsonResponse(detailedResponse)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.Found.Should().BeTrue();
+        result.Title.Should().Be("Fullmetal Alchemist Tome 23");
+        result.Authors.Should().ContainSingle().Which.Should().Be("Hiromu Arakawa");
+        result.Publishers.Should().ContainSingle().Which.Should().Be("Kurokawa");
+        result.PublishDate.Should().Be("2010-04-08");
+        result.NumberOfPages.Should().Be(176);
+        result.Language.Should().Be("fr");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_FallbackToSearchData_WhenSelfLinkFetchFails()
+    {
+        // Arrange
+        var searchResponse = """
+        {
+            "totalItems": 1,
+            "items": [{
+                "selfLink": "https://www.googleapis.com/books/v1/volumes/kOJlRgAACAAJ",
+                "volumeInfo": {
+                    "title": "Fullmetal Alchemist",
+                    "authors": ["Hiromu Arakawa"],
+                    "pageCount": 180,
+                    "language": "fr"
+                }
+            }]
+        }
+        """;
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(searchResponse),
+            ["https://www.googleapis.com/books/v1/volumes/kOJlRgAACAAJ"] = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.Found.Should().BeTrue();
+        result.Title.Should().Be("Fullmetal Alchemist");
+    }
+
+    private static HttpResponseMessage CreateJsonResponse(string json)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, HttpResponseMessage>? _responses;
+        private readonly Exception? _exception;
+
+        public MockHttpMessageHandler(Dictionary<string, HttpResponseMessage> responses)
+        {
+            _responses = responses;
+        }
+
+        public MockHttpMessageHandler(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (_exception != null)
+            {
+                throw _exception;
+            }
+
+            var url = request.RequestUri?.ToString() ?? string.Empty;
+
+            if (_responses != null && _responses.TryGetValue(url, out var response))
+            {
+                return Task.FromResult(response);
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+}

--- a/tests/Application.UnitTests/ComicInfoSearch/GoogleBooksServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/GoogleBooksServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Application.ComicInfoSearch;
+using Microsoft.Extensions.Options;
 
 namespace Application.UnitTests.ComicInfoSearch;
 
@@ -7,6 +8,10 @@ public sealed class GoogleBooksServiceTests
 {
     private const string ValidIsbn = "9782205089165";
     private const string ValidIsbnWithDashes = "978-2-205-08916-5";
+    private const string GoogleBooksBaseUrl = "https://www.googleapis.com/books/v1";
+
+    private static GoogleBooksService CreateService(HttpClient httpClient) =>
+        new(httpClient, Options.Create(new GoogleBooksSettings { BaseUrl = GoogleBooksBaseUrl }));
 
     [Fact]
     public async Task SearchByIsbnAsync_Should_ReturnBookResult_WhenBookFound()
@@ -41,7 +46,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -85,7 +90,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbnWithDashes);
@@ -107,7 +112,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -128,7 +133,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -145,7 +150,7 @@ public sealed class GoogleBooksServiceTests
             new HttpRequestException("Network error"));
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -164,7 +169,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -195,7 +200,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -227,7 +232,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -259,7 +264,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -285,7 +290,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act & Assert
         await Assert.ThrowsAsync<TaskCanceledException>(
@@ -319,7 +324,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -355,7 +360,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -392,7 +397,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -428,7 +433,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -462,7 +467,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -493,7 +498,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -520,7 +525,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -551,7 +556,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -603,7 +608,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -644,7 +649,7 @@ public sealed class GoogleBooksServiceTests
         });
 
         using var httpClient = new HttpClient(handler);
-        var service = new GoogleBooksService(httpClient);
+        var service = CreateService(httpClient);
 
         // Act
         var result = await service.SearchByIsbnAsync(ValidIsbn);

--- a/tests/Application.UnitTests/ComicInfoSearch/GoogleBooksServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/GoogleBooksServiceTests.cs
@@ -278,7 +278,7 @@ public sealed class GoogleBooksServiceTests
     }
 
     [Fact]
-    public async Task SearchByIsbnAsync_Should_HandleCancellation()
+    public async Task SearchByIsbnAsync_Should_ThrowTaskCanceledException_WhenCallerCancels()
     {
         // Arrange
         using var cts = new CancellationTokenSource();
@@ -337,7 +337,7 @@ public sealed class GoogleBooksServiceTests
     }
 
     [Fact]
-    public async Task SearchByIsbnAsync_Should_UpgradeHttpToHttps_ForCoverUrl()
+    public async Task SearchByIsbnAsync_Should_UpgradeHttpToHttps_WhenCoverUrlIsHttp()
     {
         // Arrange – realistic Google Books URL where edge=curl appears after other params
         var jsonResponse = """
@@ -446,7 +446,7 @@ public sealed class GoogleBooksServiceTests
     }
 
     [Fact]
-    public async Task SearchByIsbnAsync_Should_WrapSinglePublisher_InList()
+    public async Task SearchByIsbnAsync_Should_WrapSinglePublisher_InList_WhenPublisherIsPresent()
     {
         // Arrange
         var jsonResponse = """

--- a/tests/Application.UnitTests/ComicInfoSearch/GoogleBooksServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/GoogleBooksServiceTests.cs
@@ -334,7 +334,7 @@ public sealed class GoogleBooksServiceTests
     [Fact]
     public async Task SearchByIsbnAsync_Should_UpgradeHttpToHttps_ForCoverUrl()
     {
-        // Arrange
+        // Arrange – realistic Google Books URL where edge=curl appears after other params
         var jsonResponse = """
         {
             "totalItems": 1,
@@ -342,7 +342,7 @@ public sealed class GoogleBooksServiceTests
                 "volumeInfo": {
                     "title": "Test",
                     "imageLinks": {
-                        "thumbnail": "http://books.google.com/thumb.jpg&edge=curl"
+                        "thumbnail": "http://books.google.com/content?id=123&zoom=1&edge=curl&source=gbs_api"
                     }
                 }
             }]
@@ -364,6 +364,80 @@ public sealed class GoogleBooksServiceTests
         result.CoverUrl.Should().NotBeNull();
         result.CoverUrl!.ToString().Should().StartWith("https://");
         result.CoverUrl.ToString().Should().NotContain("edge=curl");
+        result.CoverUrl.ToString().Should().Contain("id=123");
+        result.CoverUrl.ToString().Should().Contain("source=gbs_api");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_StripEdgeParam_WhenEdgeCurlIsFirstQueryParam()
+    {
+        // Arrange – edge=curl is the first (leading) query parameter → old Replace("&edge=curl"…) would not match
+        var jsonResponse = """
+        {
+            "totalItems": 1,
+            "items": [{
+                "volumeInfo": {
+                    "title": "Test",
+                    "imageLinks": {
+                        "thumbnail": "http://books.google.com/content?edge=curl&id=123&source=gbs_api"
+                    }
+                }
+            }]
+        }
+        """;
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(jsonResponse)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.CoverUrl.Should().NotBeNull();
+        result.CoverUrl!.ToString().Should().StartWith("https://");
+        result.CoverUrl.ToString().Should().NotContain("edge=curl");
+        result.CoverUrl.ToString().Should().Contain("id=123");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_StripEdgeParam_WhenEdgeCurlIsOnlyQueryParam()
+    {
+        // Arrange – edge=curl is the only query parameter → old code left a stray '?'
+        var jsonResponse = """
+        {
+            "totalItems": 1,
+            "items": [{
+                "volumeInfo": {
+                    "title": "Test",
+                    "imageLinks": {
+                        "thumbnail": "http://books.google.com/content?edge=curl"
+                    }
+                }
+            }]
+        }
+        """;
+
+        using var handler = new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+        {
+            [$"https://www.googleapis.com/books/v1/volumes?q=isbn:{ValidIsbn}"] = CreateJsonResponse(jsonResponse)
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var service = new GoogleBooksService(httpClient);
+
+        // Act
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        // Assert
+        result.CoverUrl.Should().NotBeNull();
+        result.CoverUrl!.ToString().Should().StartWith("https://");
+        result.CoverUrl.ToString().Should().NotContain("edge");
+        result.CoverUrl.ToString().Should().NotEndWith("?");
     }
 
     [Fact]

--- a/tests/Application.UnitTests/ComicInfoSearch/GoogleBooksServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/GoogleBooksServiceTests.cs
@@ -8,7 +8,7 @@ public sealed class GoogleBooksServiceTests
 {
     private const string ValidIsbn = "9782205089165";
     private const string ValidIsbnWithDashes = "978-2-205-08916-5";
-    private const string GoogleBooksBaseUrl = "https://www.googleapis.com/books/v1";
+    private static readonly Uri GoogleBooksBaseUrl = new("https://www.googleapis.com/books/v1");
 
     private static GoogleBooksService CreateService(HttpClient httpClient) =>
         new(httpClient, Options.Create(new GoogleBooksSettings { BaseUrl = GoogleBooksBaseUrl }));


### PR DESCRIPTION
If OpenLibrary does not return a result for an ISBN, the system now queries Google Books as a fallback provider. Introduced `GoogleBooksService` and `IGoogleBooksService` for fetching and mapping Google Books metadata, including detailed volume info and best cover image selection. Updated `ComicSearchService` to use the new fallback logic and improved volume/series parsing (e.g., "Tome" patterns). Registered the Google Books HTTP client in startup and expanded unit tests to cover all fallback and mapping scenarios. Added a dedicated test suite for `GoogleBooksService`. Updated settings to allow Google Books API access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Books added as a fallback provider for ISBN searches and unified book search results.

* **Improvements**
  * Better ISBN normalization and sanitization across lookups.
  * Improved title/series/volume parsing (e.g., "Fullmetal Alchemist Tome 23").
  * Cover images from Google Books uploaded and shown when available.
  * Added configuration for Google Books API.

* **Tests**
  * Extensive unit tests for Google Books integration, parsing, images, errors, and cancellation.

* **Chores**
  * Local settings extended to allow additional fetch/command permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->