### PR TITLE
feat: Move rating from Book to ReadingDate entity

### DIFF
--- a/Application/Books/AddReadingDate/AddReadingDateCommand.cs
+++ b/Application/Books/AddReadingDate/AddReadingDateCommand.cs
@@ -1,0 +1,6 @@
+using Application.Abstractions.Messaging;
+using Domain.Books;
+
+namespace Application.Books.AddReadingDate;
+
+public record AddReadingDateCommand(Guid BookId, int Rating) : ICommand<ReadingDate>;

--- a/Application/Books/AddReadingDate/AddReadingDateCommandHandler.cs
+++ b/Application/Books/AddReadingDate/AddReadingDateCommandHandler.cs
@@ -1,0 +1,29 @@
+using Application.Abstractions.Messaging;
+using Application.Interfaces;
+using Ardalis.GuardClauses;
+using Domain.Books;
+using Domain.Primitives;
+
+namespace Application.Books.AddReadingDate;
+
+public sealed class AddReadingDateCommandHandler(IBookRepository bookRepository, IUnitOfWork unitOfWork) : ICommandHandler<AddReadingDateCommand, ReadingDate>
+{
+    public async Task<Result<ReadingDate>> Handle(AddReadingDateCommand request, CancellationToken cancellationToken)
+    {
+        Guard.Against.Null(request);
+
+        var book = await bookRepository.GetByIdAsync(request.BookId);
+        if (book is null)
+        {
+            return BooksError.NotFound;
+        }
+
+        var readingDate = book.AddReadingDate(DateTime.UtcNow, request.Rating);
+
+        bookRepository.AddReadingDate(readingDate);
+        bookRepository.Update(book);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return readingDate;
+    }
+}

--- a/Application/Books/Create/CreateBookCommandHandler.cs
+++ b/Application/Books/Create/CreateBookCommandHandler.cs
@@ -35,14 +35,11 @@ public sealed class CreateBookCommandHandler(IBookRepository bookRepository, IUn
         }
 
         // Create Book
-        var book = Book.Create(request.Serie, request.Title, normalizedIsbn, request.VolumeNumber, request.ImageLink, request.Rating,
+        var book = Book.Create(request.Serie, request.Title, normalizedIsbn, request.VolumeNumber, request.ImageLink,
             request.Authors, request.Publishers, request.PublishDate, request.NumberOfPages);
 
-        // If a rating is provided, the book has been read, so add a reading date
-        if (request.Rating > 0)
-        {
-            book.AddReadingDate(DateTime.UtcNow);
-        }
+        // Always add a reading date with the provided rating
+        book.AddReadingDate(DateTime.UtcNow, request.Rating);
 
         bookRepository.Add(book);
         await unitOfWork.SaveChangesAsync(cancellationToken);

--- a/Application/Books/DeleteReadingDate/DeleteReadingDateCommand.cs
+++ b/Application/Books/DeleteReadingDate/DeleteReadingDateCommand.cs
@@ -1,0 +1,5 @@
+using Application.Abstractions.Messaging;
+
+namespace Application.Books.DeleteReadingDate;
+
+public record DeleteReadingDateCommand(Guid BookId, Guid ReadingDateId) : ICommand;

--- a/Application/Books/DeleteReadingDate/DeleteReadingDateCommandHandler.cs
+++ b/Application/Books/DeleteReadingDate/DeleteReadingDateCommandHandler.cs
@@ -1,0 +1,28 @@
+using Application.Abstractions.Messaging;
+using Application.Interfaces;
+using Ardalis.GuardClauses;
+using Domain.Books;
+using Domain.Primitives;
+
+namespace Application.Books.DeleteReadingDate;
+
+public sealed class DeleteReadingDateCommandHandler(IBookRepository bookRepository, IUnitOfWork unitOfWork) : ICommandHandler<DeleteReadingDateCommand>
+{
+    public async Task<Result> Handle(DeleteReadingDateCommand request, CancellationToken cancellationToken)
+    {
+        Guard.Against.Null(request);
+
+        var book = await bookRepository.GetByIdAsync(request.BookId);
+        if (book is null)
+        {
+            return BooksError.NotFound;
+        }
+
+        book.RemoveReadingDate(request.ReadingDateId);
+
+        bookRepository.Update(book);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/Application/Books/Update/UpdateBookCommand.cs
+++ b/Application/Books/Update/UpdateBookCommand.cs
@@ -10,7 +10,6 @@ public record UpdateBookCommand(
     string ISBN,
     int VolumeNumber,
     string ImageLink,
-    int Rating,
     string Authors = "",
     string Publishers = "",
     DateOnly? PublishDate = null,

--- a/Application/Books/Update/UpdateBookCommandHandler.cs
+++ b/Application/Books/Update/UpdateBookCommandHandler.cs
@@ -41,7 +41,7 @@ public sealed class UpdateBookCommandHandler(IBookRepository bookRepository, IUn
         }
 
         // Update the book
-        book.Update(request.Serie, request.Title, normalizedIsbn, request.VolumeNumber, request.ImageLink, request.Rating,
+        book.Update(request.Serie, request.Title, normalizedIsbn, request.VolumeNumber, request.ImageLink,
             request.Authors, request.Publishers, request.PublishDate, request.NumberOfPages);
 
         bookRepository.Update(book);

--- a/Application/Interfaces/IBookRepository.cs
+++ b/Application/Interfaces/IBookRepository.cs
@@ -5,4 +5,5 @@ namespace Application.Interfaces;
 public interface IBookRepository : IRepository<Book, Guid>
 {
     Task<Book?> GetByIsbnAsync(string isbn, CancellationToken cancellationToken = default);
+    void AddReadingDate(ReadingDate readingDate);
 }

--- a/Domain/Books/Book.cs
+++ b/Domain/Books/Book.cs
@@ -14,8 +14,6 @@ public class Book : Entity<Guid>
 
     public string ImageLink { get; protected set; } = string.Empty;
 
-    public int Rating { get; protected set; }
-
     public string Authors { get; protected set; } = string.Empty;
 
     public string Publishers { get; protected set; } = string.Empty;
@@ -33,7 +31,6 @@ public class Book : Entity<Guid>
         string isbn,
         int volumeNumber = 1,
         string imageLink = "",
-        int rating = 0,
         string authors = "",
         string publishers = "",
         DateOnly? publishDate = null,
@@ -47,7 +44,6 @@ public class Book : Entity<Guid>
             ISBN = isbn,
             VolumeNumber = volumeNumber,
             ImageLink = imageLink,
-            Rating = rating,
             Authors = authors,
             Publishers = publishers,
             PublishDate = publishDate,
@@ -62,7 +58,6 @@ public class Book : Entity<Guid>
         string isbn,
         int volumeNumber,
         string imageLink,
-        int rating,
         string authors = "",
         string publishers = "",
         DateOnly? publishDate = null,
@@ -73,17 +68,17 @@ public class Book : Entity<Guid>
         ISBN = isbn;
         VolumeNumber = volumeNumber;
         ImageLink = imageLink;
-        Rating = rating;
         Authors = authors;
         Publishers = publishers;
         PublishDate = publishDate;
         NumberOfPages = numberOfPages;
     }
 
-    public void AddReadingDate(DateTime date)
+    public ReadingDate AddReadingDate(DateTime date, int rating)
     {
-        var readingDate = ReadingDate.Create(date, Id);
+        var readingDate = ReadingDate.Create(date, rating, Id);
         _readingDates.Add(readingDate);
+        return readingDate;
     }
 
     public void RemoveReadingDate(Guid readingDateId)
@@ -93,11 +88,5 @@ public class Book : Entity<Guid>
         {
             _readingDates.Remove(readingDate);
         }
-    }
-
-    public void UpdateReadingDate(Guid readingDateId, DateTime date)
-    {
-        var readingDate = _readingDates.Find(rd => rd.Id == readingDateId);
-        readingDate?.Update(date);
     }
 }

--- a/Domain/Books/ReadingDate.cs
+++ b/Domain/Books/ReadingDate.cs
@@ -6,21 +6,25 @@ public class ReadingDate : Entity<Guid>
 {
     public DateTime Date { get; protected set; }
 
+    public int Rating { get; protected set; }
+
     public Guid BookId { get; protected set; }
 
-    public static ReadingDate Create(DateTime date, Guid bookId)
+    public static ReadingDate Create(DateTime date, int rating, Guid bookId)
     {
         var readingDate = new ReadingDate
         {
             Id = Guid.CreateVersion7(),
             Date = date,
+            Rating = rating,
             BookId = bookId
         };
         return readingDate;
     }
 
-    public void Update(DateTime date)
+    public void Update(DateTime date, int rating)
     {
         Date = date;
+        Rating = rating;
     }
 }

--- a/Persistence/Migrations/20260222214022_MoveRatingToReadingDate.Designer.cs
+++ b/Persistence/Migrations/20260222214022_MoveRatingToReadingDate.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Persistence;
@@ -11,9 +12,11 @@ using Persistence;
 namespace Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260222214022_MoveRatingToReadingDate")]
+    partial class MoveRatingToReadingDate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Persistence/Migrations/20260222214022_MoveRatingToReadingDate.cs
+++ b/Persistence/Migrations/20260222214022_MoveRatingToReadingDate.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistence.Migrations;
+
+/// <inheritdoc />
+public partial class MoveRatingToReadingDate : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "Rating",
+            table: "Books");
+
+        migrationBuilder.AddColumn<int>(
+            name: "Rating",
+            table: "ReadingDates",
+            type: "integer",
+            nullable: false,
+            defaultValue: 0);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "Rating",
+            table: "ReadingDates");
+
+        migrationBuilder.AddColumn<int>(
+            name: "Rating",
+            table: "Books",
+            type: "integer",
+            nullable: false,
+            defaultValue: 0);
+    }
+}

--- a/Persistence/Repositories/BookRepository.cs
+++ b/Persistence/Repositories/BookRepository.cs
@@ -26,7 +26,12 @@ public class BookRepository(ApplicationDbContext dbContext) : IBookRepository
 
     public void Update(Book entity)
     {
-        dbContext.Set<Book>().Update(entity);
+        dbContext.Entry(entity).State = EntityState.Modified;
+    }
+
+    public void AddReadingDate(ReadingDate readingDate)
+    {
+        dbContext.Set<ReadingDate>().Add(readingDate);
     }
 
     public void Remove(Book entity)

--- a/Web/Components/Pages/Books/BookDetail.razor
+++ b/Web/Components/Pages/Books/BookDetail.razor
@@ -141,12 +141,15 @@
                                 </div>
                             }
 
-                            @* Rating *@
-                            @if (_book.Rating > 0)
+                            @* Latest rating *@
+                            @{
+                                var latestRating = _book.ReadingDates.MaxBy(rd => rd.Date)?.Rating ?? 0;
+                            }
+                            @if (latestRating > 0)
                             {
                                 <MudPaper Class="pa-3 rounded-lg" Elevation="0" Style="background: var(--mud-palette-background-gray);">
                                     <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-1 text-center">Your Rating</MudText>
-                                    <MudRating SelectedValue="@_book.Rating" MaxValue="5" ReadOnly="true" Size="Size.Medium" />
+                                    <MudRating SelectedValue="@latestRating" MaxValue="5" ReadOnly="true" Size="Size.Medium" />
                                 </MudPaper>
                             }
                         </div>
@@ -227,22 +230,54 @@
                                 </div>
                             }
 
-                            @* Reading status *@
+                            @* Reading history *@
                             <div class="book-detail-info-item">
-                                <MudIcon Icon="@(_book.ReadingDates.Any() ? Icons.Material.Filled.CheckCircle : Icons.Material.Outlined.RadioButtonUnchecked)"
-                                         Color="@(_book.ReadingDates.Any() ? Color.Success : Color.Secondary)" />
-                                <div>
-                                    <MudText Typo="Typo.caption" Color="Color.Secondary">Reading Status</MudText>
+                                <MudIcon Icon="@Icons.Material.Filled.MenuBook" Color="Color.Secondary" />
+                                <div style="flex: 1;">
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">Historique de lectures</MudText>
                                     @if (_book.ReadingDates.Any())
                                     {
-                                        var lastRead = _book.ReadingDates.MaxBy(rd => rd.Date);
-                                        <MudText Typo="Typo.body1" Color="Color.Success">
-                                            Read on @lastRead!.Date.ToString("dd/MM/yyyy")
-                                        </MudText>
+                                        @foreach (var rd in _book.ReadingDates.OrderByDescending(r => r.Date))
+                                        {
+                                            <div class="d-flex align-center gap-2 mt-1">
+                                                <MudRating SelectedValue="@rd.Rating" MaxValue="5" ReadOnly="true" Size="Size.Small" />
+                                                <MudText Typo="Typo.body2">@rd.Date.ToString("dd/MM/yyyy")</MudText>
+                                            </div>
+                                        }
                                     }
                                     else
                                     {
-                                        <MudText Typo="Typo.body1">Not read yet</MudText>
+                                        <MudText Typo="Typo.body1">Non lu</MudText>
+                                    }
+                                    @* Add new reading *@
+                                    @if (_showAddReading)
+                                    {
+                                        <div class="d-flex align-center gap-2 mt-2">
+                                            <MudRating @bind-SelectedValue="_newRating" MaxValue="5" Size="Size.Small" />
+                                            <MudButton Variant="Variant.Filled"
+                                                       Color="Color.Primary"
+                                                       Size="Size.Small"
+                                                       OnClick="AddReadingDateAsync"
+                                                       Disabled="_isAddingReading">
+                                                Ajouter
+                                            </MudButton>
+                                            <MudButton Variant="Variant.Text"
+                                                       Size="Size.Small"
+                                                       OnClick="@(() => _showAddReading = false)">
+                                                Annuler
+                                            </MudButton>
+                                        </div>
+                                    }
+                                    else
+                                    {
+                                        <MudButton StartIcon="@Icons.Material.Filled.Add"
+                                                   Variant="Variant.Text"
+                                                   Color="Color.Primary"
+                                                   Size="Size.Small"
+                                                   Class="mt-2"
+                                                   OnClick="@(() => _showAddReading = true)">
+                                            Ajouter une lecture
+                                        </MudButton>
                                     }
                                 </div>
                             </div>
@@ -300,6 +335,9 @@
     private Book? _book;
     private bool _isLoading = true;
     private bool _loadError;
+    private bool _showAddReading;
+    private int _newRating = 1;
+    private bool _isAddingReading;
 
     protected override async Task OnInitializedAsync()
     {
@@ -331,6 +369,33 @@
         }
 
         _isLoading = false;
+    }
+
+    private async Task AddReadingDateAsync()
+    {
+        _isAddingReading = true;
+        StateHasChanged();
+
+        try
+        {
+            var result = await BooksService.AddReadingDate(BookId, _newRating);
+
+            if (result.IsSuccess)
+            {
+                Snackbar.Add("Lecture ajoutée.", Severity.Success);
+                _showAddReading = false;
+                _newRating = 1;
+                await LoadBookAsync();
+            }
+            else
+            {
+                Snackbar.Add($"Erreur : {result.Error?.Description}", Severity.Error);
+            }
+        }
+        finally
+        {
+            _isAddingReading = false;
+        }
     }
 
     private void EditBook()

--- a/Web/Components/Pages/Books/BookForm.razor
+++ b/Web/Components/Pages/Books/BookForm.razor
@@ -40,10 +40,13 @@
                 }
 
                 @* Rating section *@
-                <MudPaper Class="pa-3 rounded-lg" Elevation="0" Style="background: var(--mud-palette-background-gray);">
-                    <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-1">Your Rating</MudText>
-                    <MudRating @bind-SelectedValue="Model.Rating" MaxValue="5" Size="Size.Medium" />
-                </MudPaper>
+                @if (ShowRating)
+                {
+                    <MudPaper Class="pa-3 rounded-lg" Elevation="0" Style="background: var(--mud-palette-background-gray);">
+                        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-1">Your Rating</MudText>
+                        <MudRating @bind-SelectedValue="Model.Rating" MaxValue="5" Size="Size.Medium" />
+                    </MudPaper>
+                }
             </div>
         </MudItem>
 
@@ -154,6 +157,9 @@
 
     [Parameter]
     public bool IsbnReadOnly { get; set; } = false;
+
+    [Parameter]
+    public bool ShowRating { get; set; } = true;
 
     private readonly BookValidator _bookValidator = new();
     private MudForm _form = default!;

--- a/Web/Components/Pages/Books/BooksList.razor
+++ b/Web/Components/Pages/Books/BooksList.razor
@@ -321,9 +321,12 @@
                                 <MudIcon Icon="@Icons.Material.Filled.QrCode" Size="Size.Small" Color="Color.Secondary" />
                                 <MudText Typo="Typo.caption" Color="Color.Secondary" Style="font-family: monospace;">@book.ISBN</MudText>
                             </div>
-                            @if (book.Rating > 0)
+                            @{
+                                var cardRating = book.ReadingDates.MaxBy(rd => rd.Date)?.Rating ?? 0;
+                            }
+                            @if (cardRating > 0)
                             {
-                                <MudRating SelectedValue="@book.Rating" MaxValue="5" ReadOnly="true" Size="Size.Small" Class="mt-1" />
+                                <MudRating SelectedValue="@cardRating" MaxValue="5" ReadOnly="true" Size="Size.Small" Class="mt-1" />
                             }
                         </div>
 
@@ -386,9 +389,12 @@
                         {
                             <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.8);">@book.Serie</MudText>
                         }
-                        @if (book.Rating > 0)
+                        @{
+                            var coverRating = book.ReadingDates.MaxBy(rd => rd.Date)?.Rating ?? 0;
+                        }
+                        @if (coverRating > 0)
                         {
-                            <MudRating SelectedValue="@book.Rating" MaxValue="5" ReadOnly="true" Size="Size.Small" Class="mt-1" />
+                            <MudRating SelectedValue="@coverRating" MaxValue="5" ReadOnly="true" Size="Size.Small" Class="mt-1" />
                         }
                     </div>
                 </MudPaper>
@@ -407,7 +413,7 @@
                 <MudTh><MudTableSortLabel SortBy="new Func<Book, object>(x => x.Serie)">Series</MudTableSortLabel></MudTh>
                 <MudTh>ISBN</MudTh>
                 <MudTh Style="text-align: center;"><MudTableSortLabel SortBy="new Func<Book, object>(x => x.VolumeNumber)">Vol.</MudTableSortLabel></MudTh>
-                <MudTh Style="text-align: center;"><MudTableSortLabel SortBy="new Func<Book, object>(x => x.Rating)">Rating</MudTableSortLabel></MudTh>
+                <MudTh Style="text-align: center;"><MudTableSortLabel SortBy="new Func<Book, object>(x => x.ReadingDates.MaxBy(rd => rd.Date)?.Rating ?? 0)">Rating</MudTableSortLabel></MudTh>
                 <MudTh Style="text-align: center;">Read</MudTh>
                 <MudTh Style="text-align: right;">Actions</MudTh>
             </HeaderContent>
@@ -437,9 +443,12 @@
                     <MudChip T="string" Size="Size.Small" Color="Color.Default">@context.VolumeNumber</MudChip>
                 </MudTd>
                 <MudTd DataLabel="Rating" Style="text-align: center;">
-                    @if (context.Rating > 0)
+                    @{
+                        var listRating = context.ReadingDates.MaxBy(rd => rd.Date)?.Rating ?? 0;
+                    }
+                    @if (listRating > 0)
                     {
-                        <MudRating SelectedValue="@context.Rating" MaxValue="5" ReadOnly="true" Size="Size.Small" />
+                        <MudRating SelectedValue="@listRating" MaxValue="5" ReadOnly="true" Size="Size.Small" />
                     }
                     else
                     {

--- a/Web/Components/Pages/Books/EditBook.razor
+++ b/Web/Components/Pages/Books/EditBook.razor
@@ -1,12 +1,15 @@
 @page "/books/{BookId}/edit"
 @rendermode InteractiveServer
 
+@using Domain.Books
 @using Microsoft.AspNetCore.Components
+@using Web.Components.Pages.Dialogs
 @using Web.Services
 @using Web.Validators
 
 @inject NavigationManager NavigationManager
 @inject IBooksService BooksService
+@inject IDialogService DialogService
 @inject ISnackbar Snackbar
 
 <style>
@@ -82,7 +85,7 @@
         else if (_bookModel is not null)
         {
             <MudPaper Class="pa-6 rounded-lg" Elevation="2">
-                <BookForm @ref="_bookForm" Model="_bookModel" />
+                <BookForm @ref="_bookForm" Model="_bookModel" ShowRating="false" />
 
                 @* Action buttons *@
                 <div class="d-flex justify-end gap-2 mt-6">
@@ -108,6 +111,34 @@
                     </MudButton>
                 </div>
             </MudPaper>
+
+            @* Reading history section *@
+            @if (_book is not null)
+            {
+                <MudPaper Class="pa-6 rounded-lg mt-4" Elevation="2">
+                    <MudText Typo="Typo.h6" Class="mb-4">Lectures</MudText>
+                    @if (_book.ReadingDates.Any())
+                    {
+                        @foreach (var rd in _book.ReadingDates.OrderByDescending(r => r.Date))
+                        {
+                            <div class="d-flex align-center justify-space-between pa-2 rounded mb-2" style="background: var(--mud-palette-background-gray);">
+                                <div class="d-flex align-center gap-3">
+                                    <MudRating SelectedValue="@rd.Rating" MaxValue="5" ReadOnly="true" Size="Size.Small" />
+                                    <MudText Typo="Typo.body2">@rd.Date.ToString("dd/MM/yyyy")</MudText>
+                                </div>
+                                <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                               Color="Color.Error"
+                                               Size="Size.Small"
+                                               OnClick="@(() => DeleteReadingDateAsync(rd.Id))" />
+                            </div>
+                        }
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">Aucune lecture enregistrée.</MudText>
+                    }
+                </MudPaper>
+            }
         }
     </div>
 </div>
@@ -118,6 +149,7 @@
 
     private BookForm? _bookForm;
     private BookUiDto? _bookModel;
+    private Book? _book;
     private bool _isLoading = true;
     private bool _loadError;
     private bool _isSaving;
@@ -139,6 +171,7 @@
 
             if (result.IsSuccess && result.Value is not null)
             {
+                _book = result.Value;
                 _bookModel = BookUiDto.Convert(result.Value);
             }
             else
@@ -175,7 +208,6 @@
                 _bookModel.ISBN,
                 _bookModel.VolumeNumber,
                 _bookModel.ImageLink,
-                _bookModel.Rating,
                 _bookModel.Authors,
                 _bookModel.Publishers,
                 _bookModel.PublishDate,
@@ -197,6 +229,41 @@
         finally
         {
             _isSaving = false;
+        }
+    }
+
+    private async Task DeleteReadingDateAsync(Guid readingDateId)
+    {
+        var parameters = new DialogParameters<ConfirmationDialog>
+        {
+            { x => x.ConfirmationMessage, "Voulez-vous vraiment supprimer cette lecture ?" },
+            { x => x.ActionText, "Supprimer" },
+            { x => x.ColorConfirmButton, Color.Error }
+        };
+
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            MaxWidth = MaxWidth.ExtraSmall,
+            CloseButton = false
+        };
+
+        var dialog = await DialogService.ShowAsync<ConfirmationDialog>("Confirmer la suppression", parameters, options);
+        var result = await dialog.Result;
+
+        if (result is not null && result.Data is not null && !result.Canceled)
+        {
+            var res = await BooksService.DeleteReadingDate(BookId, readingDateId.ToString());
+
+            if (res.IsSuccess)
+            {
+                Snackbar.Add("Lecture supprimée.", Severity.Success);
+                await LoadBookAsync();
+            }
+            else
+            {
+                Snackbar.Add($"Erreur : {res.Error?.Description}", Severity.Error);
+            }
         }
     }
 

--- a/Web/Services/AddReadingDateRequest.cs
+++ b/Web/Services/AddReadingDateRequest.cs
@@ -1,0 +1,3 @@
+namespace Web.Services;
+
+public sealed record AddReadingDateRequest(string BookId, int Rating);

--- a/Web/Services/BooksService.cs
+++ b/Web/Services/BooksService.cs
@@ -1,6 +1,8 @@
 using Application.Abstractions.Messaging;
+using Application.Books.AddReadingDate;
 using Application.Books.Create;
 using Application.Books.Delete;
+using Application.Books.DeleteReadingDate;
 using Application.Books.GetById;
 using Application.Books.List;
 using Application.Books.Update;
@@ -14,7 +16,9 @@ public class BooksService(
     IQueryHandler<GetBooksQuery, List<Book>> getBooksHandler,
     ICommandHandler<CreateBookCommand, Book> createBookHandler,
     ICommandHandler<UpdateBookCommand, Book> updateBookHandler,
-    ICommandHandler<DeleteBookCommand> deleteBookHandler) : IBooksService
+    ICommandHandler<DeleteBookCommand> deleteBookHandler,
+    ICommandHandler<AddReadingDateCommand, ReadingDate> addReadingDateHandler,
+    ICommandHandler<DeleteReadingDateCommand> deleteReadingDateHandler) : IBooksService
 {
     public async Task<Result<Book>> GetById(string? id)
     {
@@ -59,13 +63,34 @@ public class BooksService(
             request.Isbn,
             request.VolumeNumber,
             request.ImageLink,
-            request.Rating,
             request.Authors,
             request.Publishers,
             request.PublishDate,
             request.NumberOfPages);
 
         return await updateBookHandler.Handle(command, cancellationToken);
+    }
+
+    public async Task<Result<ReadingDate>> AddReadingDate(string bookId, int rating, CancellationToken cancellationToken = default)
+    {
+        if (!Guid.TryParse(bookId, out var guidId))
+        {
+            return BooksError.ValidationError;
+        }
+
+        var command = new AddReadingDateCommand(guidId, rating);
+        return await addReadingDateHandler.Handle(command, cancellationToken);
+    }
+
+    public async Task<Result> DeleteReadingDate(string bookId, string readingDateId, CancellationToken cancellationToken = default)
+    {
+        if (!Guid.TryParse(bookId, out var bookGuidId) || !Guid.TryParse(readingDateId, out var readingDateGuidId))
+        {
+            return BooksError.ValidationError;
+        }
+
+        var command = new DeleteReadingDateCommand(bookGuidId, readingDateGuidId);
+        return await deleteReadingDateHandler.Handle(command, cancellationToken);
     }
 
     public async Task<Result<List<Book>>> GetAll()

--- a/Web/Services/IBooksService.cs
+++ b/Web/Services/IBooksService.cs
@@ -14,4 +14,6 @@ public interface IBooksService
     Task<Result<Book>> Update(UpdateBookRequest request, CancellationToken cancellationToken = default);
     Task<Result<List<Book>>> GetAll();
     Task<Result> Delete(string? id, CancellationToken cancellationToken = default);
+    Task<Result<ReadingDate>> AddReadingDate(string bookId, int rating, CancellationToken cancellationToken = default);
+    Task<Result> DeleteReadingDate(string bookId, string readingDateId, CancellationToken cancellationToken = default);
 }

--- a/Web/Services/UpdateBookRequest.cs
+++ b/Web/Services/UpdateBookRequest.cs
@@ -7,7 +7,6 @@ public sealed record UpdateBookRequest(
     string Isbn,
     int VolumeNumber,
     string ImageLink,
-    int Rating,
     string Authors = "",
     string Publishers = "",
     DateOnly? PublishDate = null,

--- a/Web/Validators/BookUiDto.cs
+++ b/Web/Validators/BookUiDto.cs
@@ -46,7 +46,7 @@ public class BookUiDto : Entity<Guid>
             ISBN = book.ISBN,
             VolumeNumber = book.VolumeNumber,
             ImageLink = book.ImageLink,
-            Rating = book.Rating,
+            Rating = 0,
             Authors = book.Authors,
             Publishers = book.Publishers,
             PublishDate = book.PublishDate,

--- a/Web/Validators/BookValidator.cs
+++ b/Web/Validators/BookValidator.cs
@@ -28,7 +28,8 @@ public class BookValidator : AbstractValidator<BookUiDto>
             .MaximumLength(BookConstants.MaxImageLinkLength).WithMessage($"Image link must not exceed {BookConstants.MaxImageLinkLength} characters.");
 
         RuleFor(x => x.Rating)
-            .InclusiveBetween(0, 5).WithMessage("Rating must be between 0 and 5.");
+            .GreaterThanOrEqualTo(1).WithMessage("La note est obligatoire (1 à 5 étoiles).")
+            .LessThanOrEqualTo(5).WithMessage("La note est obligatoire (1 à 5 étoiles).");
 
         RuleFor(x => x.Authors)
             .MaximumLength(BookConstants.MaxAuthorsLength).WithMessage($"Authors must not exceed {BookConstants.MaxAuthorsLength} characters.");

--- a/tests/Application.UnitTests/Books/AddReadingDateCommandHandlerTests.cs
+++ b/tests/Application.UnitTests/Books/AddReadingDateCommandHandlerTests.cs
@@ -1,0 +1,94 @@
+using Application.Books.AddReadingDate;
+using Application.Interfaces;
+using Domain.Books;
+using NSubstitute;
+
+namespace Application.UnitTests.Books;
+
+public class AddReadingDateCommandHandlerTests
+{
+    private readonly AddReadingDateCommandHandler _handler;
+    private readonly IBookRepository _bookRepositoryMock;
+    private readonly IUnitOfWork _unitOfWorkMock;
+
+    public AddReadingDateCommandHandlerTests()
+    {
+        _bookRepositoryMock = Substitute.For<IBookRepository>();
+        _unitOfWorkMock = Substitute.For<IUnitOfWork>();
+        _handler = new AddReadingDateCommandHandler(_bookRepositoryMock, _unitOfWorkMock);
+    }
+
+    [Fact]
+    public async Task Handle_Should_ReturnNotFound_WhenBookDoesNotExist()
+    {
+        // Arrange
+        var command = new AddReadingDateCommand(Guid.NewGuid(), 4);
+        _bookRepositoryMock.GetByIdAsync(command.BookId).Returns((Book?)null);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(BooksError.NotFound);
+        _bookRepositoryMock.DidNotReceive().AddReadingDate(Arg.Any<ReadingDate>());
+        _bookRepositoryMock.DidNotReceive().Update(Arg.Any<Book>());
+        await _unitOfWorkMock.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_Should_ReturnSuccess_WhenBookExists()
+    {
+        // Arrange
+        var book = Book.Create("Serie", "Title", "978-3-16-148410-0");
+        var command = new AddReadingDateCommand(book.Id, 5);
+        _bookRepositoryMock.GetByIdAsync(command.BookId).Returns(book);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Rating.Should().Be(5);
+        book.ReadingDates.Should().HaveCount(1);
+        _bookRepositoryMock.Received(1).AddReadingDate(Arg.Any<ReadingDate>());
+        _bookRepositoryMock.Received(1).Update(book);
+        await _unitOfWorkMock.Received(1).SaveChangesAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Handle_Should_AddReadingDateWithCorrectRating()
+    {
+        // Arrange
+        var book = Book.Create("Serie", "Title", "978-3-16-148410-0");
+        const int rating = 3;
+        var command = new AddReadingDateCommand(book.Id, rating);
+        _bookRepositoryMock.GetByIdAsync(command.BookId).Returns(book);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        book.ReadingDates.Should().HaveCount(1);
+        book.ReadingDates[0].Rating.Should().Be(rating);
+        book.ReadingDates[0].BookId.Should().Be(book.Id);
+    }
+
+    [Fact]
+    public async Task Handle_Should_PassCancellationToken()
+    {
+        // Arrange
+        var book = Book.Create("Serie", "Title", "978-3-16-148410-0");
+        var command = new AddReadingDateCommand(book.Id, 4);
+        var cancellationToken = new CancellationToken();
+        _bookRepositoryMock.GetByIdAsync(command.BookId).Returns(book);
+
+        // Act
+        await _handler.Handle(command, cancellationToken);
+
+        // Assert
+        await _unitOfWorkMock.Received(1).SaveChangesAsync(cancellationToken);
+    }
+}

--- a/tests/Application.UnitTests/Books/CreateBookCommandHandlerTests.cs
+++ b/tests/Application.UnitTests/Books/CreateBookCommandHandlerTests.cs
@@ -48,8 +48,8 @@ public class CreateBookCommandHandlerTests
         result.Value.ISBN.Should().Be(IsbnHelper.NormalizeIsbn(s_validCommand.ISBN));
         result.Value.VolumeNumber.Should().Be(s_validCommand.VolumeNumber);
         result.Value.ImageLink.Should().Be(s_validCommand.ImageLink);
-        result.Value.Rating.Should().Be(s_validCommand.Rating);
         result.Value.ReadingDates.Should().HaveCount(1);
+        result.Value.ReadingDates[0].Rating.Should().Be(s_validCommand.Rating);
         _bookRepositoryMock.Received(1).Add(Arg.Any<Book>());
         await _unitOfWorkMock.Received(1).SaveChangesAsync(CancellationToken.None);
     }
@@ -167,7 +167,7 @@ public class CreateBookCommandHandlerTests
     [Fact]
     public async Task Handle_ShouldReturnDuplicate_WhenBookWithSameISBNAlreadyExists()
     {
-        // Arrange        
+        // Arrange
         var existingBook = Book.Create(s_validCommand.Serie, s_validCommand.Title, s_validCommand.ISBN);
         var normalizedIsbn = IsbnHelper.NormalizeIsbn(s_validCommand.ISBN);
         _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>()).Returns(existingBook);
@@ -236,13 +236,14 @@ public class CreateBookCommandHandlerTests
         Guard.Against.Null(result.Value);
         result.Value.VolumeNumber.Should().Be(1);
         result.Value.ImageLink.Should().Be(string.Empty);
-        result.Value.ReadingDates.Should().BeEmpty();
+        result.Value.ReadingDates.Should().HaveCount(1);
+        result.Value.ReadingDates[0].Rating.Should().Be(0);
         _bookRepositoryMock.Received(1).Add(Arg.Any<Book>());
         await _unitOfWorkMock.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task Handle_Should_AddReadingDate_WhenRatingIsProvided()
+    public async Task Handle_Should_AddReadingDate_WithRatingOnReadingDate_WhenRatingIsProvided()
     {
         // Arrange
         var commandWithRating = new CreateBookCommand("Serie", "Title", "978-3-16-148410-0", 1, "", 5);
@@ -255,12 +256,12 @@ public class CreateBookCommandHandlerTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         Guard.Against.Null(result.Value);
-        result.Value.Rating.Should().Be(5);
         result.Value.ReadingDates.Should().HaveCount(1);
+        result.Value.ReadingDates[0].Rating.Should().Be(5);
     }
 
     [Fact]
-    public async Task Handle_Should_NotAddReadingDate_WhenRatingIsZero()
+    public async Task Handle_Should_AlwaysAddReadingDate_EvenWhenRatingIsZero()
     {
         // Arrange
         var commandWithoutRating = new CreateBookCommand("Serie", "Title", "978-3-16-148410-0", 1, "", 0);
@@ -273,8 +274,8 @@ public class CreateBookCommandHandlerTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         Guard.Against.Null(result.Value);
-        result.Value.Rating.Should().Be(0);
-        result.Value.ReadingDates.Should().BeEmpty();
+        result.Value.ReadingDates.Should().HaveCount(1);
+        result.Value.ReadingDates[0].Rating.Should().Be(0);
     }
 
     [Fact]
@@ -624,12 +625,12 @@ public class CreateBookCommandHandlerTests
         result.Value.ISBN.Should().Be(normalizedIsbn);
         result.Value.VolumeNumber.Should().Be(volumeNumber);
         result.Value.ImageLink.Should().Be(imageLink);
-        result.Value.Rating.Should().Be(rating);
         result.Value.Authors.Should().Be(authors);
         result.Value.Publishers.Should().Be(publishers);
         result.Value.PublishDate.Should().Be(publishDate);
         result.Value.NumberOfPages.Should().Be(numberOfPages);
-        result.Value.ReadingDates.Should().HaveCount(1); // Rating > 0, so reading date is added
+        result.Value.ReadingDates.Should().HaveCount(1);
+        result.Value.ReadingDates[0].Rating.Should().Be(rating);
     }
 
     #endregion

--- a/tests/Application.UnitTests/Books/DeleteReadingDateCommandHandlerTests.cs
+++ b/tests/Application.UnitTests/Books/DeleteReadingDateCommandHandlerTests.cs
@@ -1,0 +1,93 @@
+using Application.Books.DeleteReadingDate;
+using Application.Interfaces;
+using Domain.Books;
+using NSubstitute;
+
+namespace Application.UnitTests.Books;
+
+public class DeleteReadingDateCommandHandlerTests
+{
+    private readonly DeleteReadingDateCommandHandler _handler;
+    private readonly IBookRepository _bookRepositoryMock;
+    private readonly IUnitOfWork _unitOfWorkMock;
+
+    public DeleteReadingDateCommandHandlerTests()
+    {
+        _bookRepositoryMock = Substitute.For<IBookRepository>();
+        _unitOfWorkMock = Substitute.For<IUnitOfWork>();
+        _handler = new DeleteReadingDateCommandHandler(_bookRepositoryMock, _unitOfWorkMock);
+    }
+
+    [Fact]
+    public async Task Handle_Should_ReturnNotFound_WhenBookDoesNotExist()
+    {
+        // Arrange
+        var command = new DeleteReadingDateCommand(Guid.NewGuid(), Guid.NewGuid());
+        _bookRepositoryMock.GetByIdAsync(command.BookId).Returns((Book?)null);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(BooksError.NotFound);
+        _bookRepositoryMock.DidNotReceive().Update(Arg.Any<Book>());
+        await _unitOfWorkMock.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_Should_ReturnSuccess_AndRemoveReadingDate_WhenBookExists()
+    {
+        // Arrange
+        var book = Book.Create("Serie", "Title", "978-3-16-148410-0");
+        book.AddReadingDate(DateTime.UtcNow, 4);
+        var readingDateId = book.ReadingDates[0].Id;
+        var command = new DeleteReadingDateCommand(book.Id, readingDateId);
+        _bookRepositoryMock.GetByIdAsync(command.BookId).Returns(book);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        book.ReadingDates.Should().BeEmpty();
+        _bookRepositoryMock.Received(1).Update(book);
+        await _unitOfWorkMock.Received(1).SaveChangesAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Handle_Should_ReturnSuccess_WhenReadingDateDoesNotExist()
+    {
+        // Arrange
+        var book = Book.Create("Serie", "Title", "978-3-16-148410-0");
+        book.AddReadingDate(DateTime.UtcNow, 4);
+        var nonExistentReadingDateId = Guid.NewGuid();
+        var command = new DeleteReadingDateCommand(book.Id, nonExistentReadingDateId);
+        _bookRepositoryMock.GetByIdAsync(command.BookId).Returns(book);
+
+        // Act
+        var result = await _handler.Handle(command, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        book.ReadingDates.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Handle_Should_PassCancellationToken()
+    {
+        // Arrange
+        var book = Book.Create("Serie", "Title", "978-3-16-148410-0");
+        book.AddReadingDate(DateTime.UtcNow, 3);
+        var readingDateId = book.ReadingDates[0].Id;
+        var command = new DeleteReadingDateCommand(book.Id, readingDateId);
+        var cancellationToken = new CancellationToken();
+        _bookRepositoryMock.GetByIdAsync(command.BookId).Returns(book);
+
+        // Act
+        await _handler.Handle(command, cancellationToken);
+
+        // Assert
+        await _unitOfWorkMock.Received(1).SaveChangesAsync(cancellationToken);
+    }
+}

--- a/tests/Application.UnitTests/Books/UpdateBookCommandHandlerTests.cs
+++ b/tests/Application.UnitTests/Books/UpdateBookCommandHandlerTests.cs
@@ -16,8 +16,7 @@ public class UpdateBookCommandHandlerTests
         "Updated Title",
         "978-0-306-40615-7",
         2,
-        "https://example.com/updated.jpg",
-        5
+        "https://example.com/updated.jpg"
     );
 
     private readonly UpdateBookCommandHandler _handler;
@@ -86,7 +85,7 @@ public class UpdateBookCommandHandlerTests
     public async Task Handle_ShouldReturnBadRequest_WhenTitleIsEmpty()
     {
         // Arrange
-        var emptyTitleCommand = new UpdateBookCommand(s_bookId, "Serie", string.Empty, "978-3-16-148410-0", 1, "", 0);
+        var emptyTitleCommand = new UpdateBookCommand(s_bookId, "Serie", string.Empty, "978-3-16-148410-0", 1, "");
 
         // Act
         var result = await _handler.Handle(emptyTitleCommand, default);
@@ -102,7 +101,7 @@ public class UpdateBookCommandHandlerTests
     public async Task Handle_ShouldReturnBadRequest_WhenTitleIsNull()
     {
         // Arrange
-        var nullTitleCommand = new UpdateBookCommand(s_bookId, "Serie", null!, "978-3-16-148410-0", 1, "", 0);
+        var nullTitleCommand = new UpdateBookCommand(s_bookId, "Serie", null!, "978-3-16-148410-0", 1, "");
 
         // Act
         var result = await _handler.Handle(nullTitleCommand, default);
@@ -118,7 +117,7 @@ public class UpdateBookCommandHandlerTests
     public async Task Handle_ShouldReturnBadRequest_WhenISBNIsEmpty()
     {
         // Arrange
-        var emptyIsbnCommand = new UpdateBookCommand(s_bookId, "Serie", "Title", string.Empty, 1, "", 0);
+        var emptyIsbnCommand = new UpdateBookCommand(s_bookId, "Serie", "Title", string.Empty, 1, "");
 
         // Act
         var result = await _handler.Handle(emptyIsbnCommand, default);
@@ -134,7 +133,7 @@ public class UpdateBookCommandHandlerTests
     public async Task Handle_ShouldReturnBadRequest_WhenISBNIsNull()
     {
         // Arrange
-        var nullIsbnCommand = new UpdateBookCommand(s_bookId, "Serie", "Title", null!, 1, "", 0);
+        var nullIsbnCommand = new UpdateBookCommand(s_bookId, "Serie", "Title", null!, 1, "");
 
         // Act
         var result = await _handler.Handle(nullIsbnCommand, default);
@@ -150,7 +149,7 @@ public class UpdateBookCommandHandlerTests
     public async Task Handle_ShouldReturnInvalidISBN_WhenISBNFormatIsInvalid()
     {
         // Arrange
-        var invalidIsbnCommand = new UpdateBookCommand(s_bookId, "Serie", "Title", "invalid-isbn", 1, "", 0);
+        var invalidIsbnCommand = new UpdateBookCommand(s_bookId, "Serie", "Title", "invalid-isbn", 1, "");
 
         // Act
         var result = await _handler.Handle(invalidIsbnCommand, default);
@@ -166,7 +165,7 @@ public class UpdateBookCommandHandlerTests
     public async Task Handle_ShouldReturnInvalidISBN_WhenISBNHasInvalidLength()
     {
         // Arrange
-        var invalidLengthCommand = new UpdateBookCommand(s_bookId, "Serie", "Title", "12345", 1, "", 0);
+        var invalidLengthCommand = new UpdateBookCommand(s_bookId, "Serie", "Title", "12345", 1, "");
 
         // Act
         var result = await _handler.Handle(invalidLengthCommand, default);
@@ -227,8 +226,7 @@ public class UpdateBookCommandHandlerTests
             "Updated Title",
             existingBook.ISBN, // Same ISBN as existing book
             2,
-            "https://example.com/updated.jpg",
-            3
+            "https://example.com/updated.jpg"
         );
 
         _bookRepositoryMock.GetByIdAsync(commandWithSameISBN.Id).Returns(existingBook);
@@ -302,7 +300,7 @@ public class UpdateBookCommandHandlerTests
     {
         // Arrange
         var existingBook = CreateBookWithId(s_bookId, "Original Serie", "Original Title", "978-3-16-148410-0");
-        var isbn10Command = new UpdateBookCommand(s_bookId, "Serie", "Title", "0-306-40615-2", 1, "", 0);
+        var isbn10Command = new UpdateBookCommand(s_bookId, "Serie", "Title", "0-306-40615-2", 1, "");
         _bookRepositoryMock.GetByIdAsync(isbn10Command.Id).Returns(existingBook);
         _bookRepositoryMock.GetByIsbnAsync("0306406152", Arg.Any<CancellationToken>()).Returns((Book?)null);
 
@@ -322,7 +320,7 @@ public class UpdateBookCommandHandlerTests
     {
         // Arrange
         var existingBook = CreateBookWithId(s_bookId, "Original Serie", "Original Title", "978-3-16-148410-0");
-        var isbn13Command = new UpdateBookCommand(s_bookId, "Serie", "Title", "978-0-306-40615-7", 1, "", 0);
+        var isbn13Command = new UpdateBookCommand(s_bookId, "Serie", "Title", "978-0-306-40615-7", 1, "");
         _bookRepositoryMock.GetByIdAsync(isbn13Command.Id).Returns(existingBook);
         _bookRepositoryMock.GetByIsbnAsync("9780306406157", Arg.Any<CancellationToken>()).Returns((Book?)null);
 
@@ -342,7 +340,7 @@ public class UpdateBookCommandHandlerTests
     {
         // Arrange
         var existingBook = CreateBookWithId(s_bookId, "Original Serie", "Original Title", "978-3-16-148410-0");
-        var updateVolumeCommand = new UpdateBookCommand(s_bookId, "Serie", "Title", "978-3-16-148410-0", 5, "", 0);
+        var updateVolumeCommand = new UpdateBookCommand(s_bookId, "Serie", "Title", "978-3-16-148410-0", 5, "");
         _bookRepositoryMock.GetByIdAsync(updateVolumeCommand.Id).Returns(existingBook);
         _bookRepositoryMock.GetByIsbnAsync("9783161484100", Arg.Any<CancellationToken>()).Returns(existingBook);
 
@@ -360,7 +358,7 @@ public class UpdateBookCommandHandlerTests
     {
         // Arrange
         var existingBook = CreateBookWithId(s_bookId, "Original Serie", "Original Title", "978-3-16-148410-0");
-        var updateImageCommand = new UpdateBookCommand(s_bookId, "Serie", "Title", "978-3-16-148410-0", 1, "https://new-image.com/cover.jpg", 0);
+        var updateImageCommand = new UpdateBookCommand(s_bookId, "Serie", "Title", "978-3-16-148410-0", 1, "https://new-image.com/cover.jpg");
         _bookRepositoryMock.GetByIdAsync(updateImageCommand.Id).Returns(existingBook);
         _bookRepositoryMock.GetByIsbnAsync("9783161484100", Arg.Any<CancellationToken>()).Returns(existingBook);
 
@@ -378,7 +376,7 @@ public class UpdateBookCommandHandlerTests
     {
         // Arrange
         var existingBook = CreateBookWithId(s_bookId, "Original Serie", "Original Title", "978-3-16-148410-0");
-        var emptyImageCommand = new UpdateBookCommand(s_bookId, "Serie", "Title", "978-3-16-148410-0", 1, "", 0);
+        var emptyImageCommand = new UpdateBookCommand(s_bookId, "Serie", "Title", "978-3-16-148410-0", 1, "");
         _bookRepositoryMock.GetByIdAsync(emptyImageCommand.Id).Returns(existingBook);
         _bookRepositoryMock.GetByIsbnAsync("9783161484100", Arg.Any<CancellationToken>()).Returns(existingBook);
 
@@ -408,7 +406,7 @@ public class UpdateBookCommandHandlerTests
     public async Task Handle_Should_NotCallSaveChanges_WhenValidationFails()
     {
         // Arrange
-        var invalidCommand = new UpdateBookCommand(s_bookId, "Serie", "", "978-3-16-148410-0", 1, "", 0);
+        var invalidCommand = new UpdateBookCommand(s_bookId, "Serie", "", "978-3-16-148410-0", 1, "");
 
         // Act
         await _handler.Handle(invalidCommand, default);
@@ -436,7 +434,7 @@ public class UpdateBookCommandHandlerTests
         _bookRepositoryMock.GetByIsbnAsync("9780306406157", Arg.Any<CancellationToken>()).Returns(book2);
 
         // Command tries to update book1 to have the same ISBN as book2
-        var duplicateCommand = new UpdateBookCommand(bookId1, "Serie", "Title", book2.ISBN, 1, "", 0);
+        var duplicateCommand = new UpdateBookCommand(bookId1, "Serie", "Title", book2.ISBN, 1, "");
 
         // Act
         var result = await _handler.Handle(duplicateCommand, default);

--- a/tests/Domain.UnitTests/Books/BookTests.cs
+++ b/tests/Domain.UnitTests/Books/BookTests.cs
@@ -23,7 +23,6 @@ public class BookTests
         book.ISBN.Should().Be(isbn);
         book.VolumeNumber.Should().Be(1);
         book.ImageLink.Should().Be(string.Empty);
-        book.Rating.Should().Be(0);
         book.ReadingDates.Should().BeEmpty();
     }
 
@@ -47,12 +46,11 @@ public class BookTests
         book.ISBN.Should().Be(isbn);
         book.VolumeNumber.Should().Be(volumeNumber);
         book.ImageLink.Should().Be(string.Empty);
-        book.Rating.Should().Be(0);
         book.ReadingDates.Should().BeEmpty();
     }
 
     [Fact]
-    public void Create_Should_CreateBookWithAllProperties()
+    public void Create_Should_CreateBookWithImageLink()
     {
         // Arrange
         const string series = "The Sandman";
@@ -60,10 +58,9 @@ public class BookTests
         const string isbn = "9781401284794";
         const int volumeNumber = 3;
         const string imageLink = "https://example.com/image.jpg";
-        const int rating = 4;
 
         // Act
-        var book = Book.Create(series, title, isbn, volumeNumber, imageLink, rating);
+        var book = Book.Create(series, title, isbn, volumeNumber, imageLink);
 
         // Assert
         book.Should().NotBeNull();
@@ -73,7 +70,6 @@ public class BookTests
         book.ISBN.Should().Be(isbn);
         book.VolumeNumber.Should().Be(volumeNumber);
         book.ImageLink.Should().Be(imageLink);
-        book.Rating.Should().Be(rating);
         book.ReadingDates.Should().BeEmpty();
     }
 
@@ -101,14 +97,13 @@ public class BookTests
         const string isbn = "9781607066019";
         const int volumeNumber = 1;
         const string imageLink = "https://example.com/saga.jpg";
-        const int rating = 5;
         const string authors = "Brian K. Vaughan, Fiona Staples";
         const string publishers = "Image Comics";
         var publishDate = new DateOnly(2012, 10, 10);
         const int numberOfPages = 160;
 
         // Act
-        var book = Book.Create(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+        var book = Book.Create(series, title, isbn, volumeNumber, imageLink, authors, publishers, publishDate, numberOfPages);
 
         // Assert
         book.Should().NotBeNull();
@@ -118,7 +113,6 @@ public class BookTests
         book.ISBN.Should().Be(isbn);
         book.VolumeNumber.Should().Be(volumeNumber);
         book.ImageLink.Should().Be(imageLink);
-        book.Rating.Should().Be(rating);
         book.Authors.Should().Be(authors);
         book.Publishers.Should().Be(publishers);
         book.PublishDate.Should().Be(publishDate);
@@ -146,7 +140,6 @@ public class BookTests
         book.NumberOfPages.Should().BeNull();
         book.VolumeNumber.Should().Be(1);
         book.ImageLink.Should().BeEmpty();
-        book.Rating.Should().Be(0);
     }
 
     [Fact]
@@ -201,7 +194,6 @@ public class BookTests
         // Assert
         book.VolumeNumber.Should().Be(1);
         book.ImageLink.Should().BeEmpty();
-        book.Rating.Should().Be(0);
         book.Authors.Should().BeEmpty();
         book.Publishers.Should().BeEmpty();
         book.PublishDate.Should().BeNull();
@@ -218,10 +210,9 @@ public class BookTests
         const string newIsbn = "9876543210";
         const int newVolumeNumber = 5;
         const string newImageLink = "https://example.com/new-image.jpg";
-        const int newRating = 5;
 
         // Act
-        book.Update(newSeries, newTitle, newIsbn, newVolumeNumber, newImageLink, newRating);
+        book.Update(newSeries, newTitle, newIsbn, newVolumeNumber, newImageLink);
 
         // Assert
         book.Serie.Should().Be(newSeries);
@@ -229,7 +220,6 @@ public class BookTests
         book.ISBN.Should().Be(newIsbn);
         book.VolumeNumber.Should().Be(newVolumeNumber);
         book.ImageLink.Should().Be(newImageLink);
-        book.Rating.Should().Be(newRating);
     }
 
     [Fact]
@@ -246,14 +236,13 @@ public class BookTests
         const string newIsbn = "9876543210";
         const int newVolumeNumber = 3;
         const string newImageLink = "https://example.com/updated.jpg";
-        const int newRating = 4;
         const string newAuthors = "New Author, Second Author";
         const string newPublishers = "New Publisher";
         var newPublishDate = new DateOnly(2024, 6, 15);
         const int newNumberOfPages = 250;
 
         // Act
-        book.Update(newSeries, newTitle, newIsbn, newVolumeNumber, newImageLink, newRating,
+        book.Update(newSeries, newTitle, newIsbn, newVolumeNumber, newImageLink,
             newAuthors, newPublishers, newPublishDate, newNumberOfPages);
 
         // Assert
@@ -262,7 +251,6 @@ public class BookTests
         book.ISBN.Should().Be(newIsbn);
         book.VolumeNumber.Should().Be(newVolumeNumber);
         book.ImageLink.Should().Be(newImageLink);
-        book.Rating.Should().Be(newRating);
         book.Authors.Should().Be(newAuthors);
         book.Publishers.Should().Be(newPublishers);
         book.PublishDate.Should().Be(newPublishDate);
@@ -278,7 +266,7 @@ public class BookTests
         const string newPublishers = "DC Comics, Vertigo";
 
         // Act
-        book.Update(book.Serie, book.Title, book.ISBN, book.VolumeNumber, book.ImageLink, book.Rating,
+        book.Update(book.Serie, book.Title, book.ISBN, book.VolumeNumber, book.ImageLink,
             newAuthors, newPublishers);
 
         // Assert
@@ -297,7 +285,7 @@ public class BookTests
         const int newNumberOfPages = 320;
 
         // Act
-        book.Update(book.Serie, book.Title, book.ISBN, book.VolumeNumber, book.ImageLink, book.Rating,
+        book.Update(book.Serie, book.Title, book.ISBN, book.VolumeNumber, book.ImageLink,
             publishDate: newPublishDate, numberOfPages: newNumberOfPages);
 
         // Assert
@@ -317,7 +305,7 @@ public class BookTests
             publishDate: originalPublishDate, numberOfPages: 100);
 
         // Act
-        book.Update(book.Serie, book.Title, book.ISBN, book.VolumeNumber, book.ImageLink, book.Rating,
+        book.Update(book.Serie, book.Title, book.ISBN, book.VolumeNumber, book.ImageLink,
             "", "", null, null);
 
         // Assert
@@ -340,7 +328,7 @@ public class BookTests
         const string newTitle = "New Title";
 
         // Act - update basic properties without metadata parameters
-        book.Update(newSeries, newTitle, book.ISBN, book.VolumeNumber, book.ImageLink, book.Rating);
+        book.Update(newSeries, newTitle, book.ISBN, book.VolumeNumber, book.ImageLink);
 
         // Assert - metadata should be cleared to defaults when not provided
         book.Serie.Should().Be(newSeries);
@@ -359,11 +347,12 @@ public class BookTests
         var date = new DateTime(2024, 1, 15);
 
         // Act
-        book.AddReadingDate(date);
+        book.AddReadingDate(date, 4);
 
         // Assert
         book.ReadingDates.Should().HaveCount(1);
         book.ReadingDates[0].Date.Should().Be(date);
+        book.ReadingDates[0].Rating.Should().Be(4);
         book.ReadingDates[0].BookId.Should().Be(book.Id);
     }
 
@@ -376,13 +365,15 @@ public class BookTests
         var date2 = new DateTime(2024, 1, 15);
 
         // Act
-        book.AddReadingDate(date1);
-        book.AddReadingDate(date2);
+        book.AddReadingDate(date1, 3);
+        book.AddReadingDate(date2, 5);
 
         // Assert
         book.ReadingDates.Should().HaveCount(2);
         book.ReadingDates[0].Date.Should().Be(date1);
+        book.ReadingDates[0].Rating.Should().Be(3);
         book.ReadingDates[1].Date.Should().Be(date2);
+        book.ReadingDates[1].Rating.Should().Be(5);
     }
 
     [Fact]
@@ -391,7 +382,7 @@ public class BookTests
         // Arrange
         var book = Book.Create("Saga", "Volume 1", "9781607066017");
         var date = new DateTime(2024, 1, 15);
-        book.AddReadingDate(date);
+        book.AddReadingDate(date, 4);
         var readingDateId = book.ReadingDates[0].Id;
 
         // Act
@@ -407,7 +398,7 @@ public class BookTests
         // Arrange
         var book = Book.Create("Fables", "Volume 1", "9781563899423");
         var date = new DateTime(2024, 1, 15);
-        book.AddReadingDate(date);
+        book.AddReadingDate(date, 3);
         var nonExistentId = Guid.NewGuid();
 
         // Act
@@ -424,8 +415,8 @@ public class BookTests
         var book = Book.Create("Y: The Last Man", "Volume 1", "9781401219512");
         var date1 = new DateTime(2023, 6, 1);
         var date2 = new DateTime(2024, 1, 15);
-        book.AddReadingDate(date1);
-        book.AddReadingDate(date2);
+        book.AddReadingDate(date1, 3);
+        book.AddReadingDate(date2, 5);
         var firstReadingDateId = book.ReadingDates[0].Id;
 
         // Act
@@ -437,47 +428,11 @@ public class BookTests
     }
 
     [Fact]
-    public void UpdateReadingDate_Should_UpdateDate()
-    {
-        // Arrange
-        var book = Book.Create("Preacher", "Volume 1", "9781401240455");
-        var originalDate = new DateTime(2024, 1, 15);
-        book.AddReadingDate(originalDate);
-        var readingDateId = book.ReadingDates[0].Id;
-        var newDate = new DateTime(2024, 2, 20);
-
-        // Act
-        book.UpdateReadingDate(readingDateId, newDate);
-
-        // Assert
-        book.ReadingDates.Should().HaveCount(1);
-        book.ReadingDates[0].Date.Should().Be(newDate);
-    }
-
-    [Fact]
-    public void UpdateReadingDate_Should_DoNothing_WhenReadingDateNotFound()
-    {
-        // Arrange
-        var book = Book.Create("Transmetropolitan", "Volume 1", "9781401220846");
-        var originalDate = new DateTime(2024, 1, 15);
-        book.AddReadingDate(originalDate);
-        var nonExistentId = Guid.NewGuid();
-        var newDate = new DateTime(2024, 2, 20);
-
-        // Act
-        book.UpdateReadingDate(nonExistentId, newDate);
-
-        // Assert
-        book.ReadingDates.Should().HaveCount(1);
-        book.ReadingDates[0].Date.Should().Be(originalDate);
-    }
-
-    [Fact]
     public void ReadingDates_Should_ReturnReadOnlyCollection()
     {
         // Arrange
         var book = Book.Create("The Walking Dead", "Volume 1", "9781582406190");
-        book.AddReadingDate(new DateTime(2024, 1, 15));
+        book.AddReadingDate(new DateTime(2024, 1, 15), 4);
 
         // Act
         var readingDates = book.ReadingDates;

--- a/tests/Domain.UnitTests/Books/ReadingDateTests.cs
+++ b/tests/Domain.UnitTests/Books/ReadingDateTests.cs
@@ -10,14 +10,16 @@ public class ReadingDateTests
         // Arrange
         var date = new DateTime(2024, 1, 15, 10, 30, 0);
         var bookId = Guid.NewGuid();
+        const int rating = 4;
 
         // Act
-        var readingDate = ReadingDate.Create(date, bookId);
+        var readingDate = ReadingDate.Create(date, rating, bookId);
 
         // Assert
         readingDate.Should().NotBeNull();
         readingDate.Id.Should().NotBe(Guid.Empty);
         readingDate.Date.Should().Be(date);
+        readingDate.Rating.Should().Be(rating);
         readingDate.BookId.Should().Be(bookId);
     }
 
@@ -29,7 +31,7 @@ public class ReadingDateTests
         var bookId = Guid.NewGuid();
 
         // Act
-        var readingDate = ReadingDate.Create(date, bookId);
+        var readingDate = ReadingDate.Create(date, 3, bookId);
 
         // Assert
         readingDate.Id.Should().NotBe(Guid.Empty);
@@ -43,27 +45,28 @@ public class ReadingDateTests
         var bookId = Guid.NewGuid();
 
         // Act
-        var readingDate1 = ReadingDate.Create(date, bookId);
-        var readingDate2 = ReadingDate.Create(date, bookId);
+        var readingDate1 = ReadingDate.Create(date, 3, bookId);
+        var readingDate2 = ReadingDate.Create(date, 3, bookId);
 
         // Assert
         readingDate1.Id.Should().NotBe(readingDate2.Id);
     }
 
     [Fact]
-    public void Update_Should_UpdateDate()
+    public void Update_Should_UpdateDateAndRating()
     {
         // Arrange
         var originalDate = new DateTime(2024, 1, 15);
         var bookId = Guid.NewGuid();
-        var readingDate = ReadingDate.Create(originalDate, bookId);
+        var readingDate = ReadingDate.Create(originalDate, 3, bookId);
         var newDate = new DateTime(2024, 2, 20);
 
         // Act
-        readingDate.Update(newDate);
+        readingDate.Update(newDate, 5);
 
         // Assert
         readingDate.Date.Should().Be(newDate);
+        readingDate.Rating.Should().Be(5);
     }
 
     [Fact]
@@ -72,11 +75,11 @@ public class ReadingDateTests
         // Arrange
         var originalDate = new DateTime(2024, 1, 15);
         var bookId = Guid.NewGuid();
-        var readingDate = ReadingDate.Create(originalDate, bookId);
+        var readingDate = ReadingDate.Create(originalDate, 3, bookId);
         var newDate = new DateTime(2024, 2, 20);
 
         // Act
-        readingDate.Update(newDate);
+        readingDate.Update(newDate, 4);
 
         // Assert
         readingDate.BookId.Should().Be(bookId);
@@ -88,12 +91,12 @@ public class ReadingDateTests
         // Arrange
         var originalDate = new DateTime(2024, 1, 15);
         var bookId = Guid.NewGuid();
-        var readingDate = ReadingDate.Create(originalDate, bookId);
+        var readingDate = ReadingDate.Create(originalDate, 3, bookId);
         var originalId = readingDate.Id;
         var newDate = new DateTime(2024, 2, 20);
 
         // Act
-        readingDate.Update(newDate);
+        readingDate.Update(newDate, 4);
 
         // Assert
         readingDate.Id.Should().Be(originalId);
@@ -105,17 +108,18 @@ public class ReadingDateTests
         // Arrange
         var originalDate = new DateTime(2024, 1, 15);
         var bookId = Guid.NewGuid();
-        var readingDate = ReadingDate.Create(originalDate, bookId);
+        var readingDate = ReadingDate.Create(originalDate, 2, bookId);
 
         var secondDate = new DateTime(2024, 2, 20);
         var thirdDate = new DateTime(2024, 3, 25);
 
         // Act
-        readingDate.Update(secondDate);
-        readingDate.Update(thirdDate);
+        readingDate.Update(secondDate, 3);
+        readingDate.Update(thirdDate, 5);
 
         // Assert
         readingDate.Date.Should().Be(thirdDate);
+        readingDate.Rating.Should().Be(5);
         readingDate.BookId.Should().Be(bookId);
     }
 
@@ -127,7 +131,7 @@ public class ReadingDateTests
         var bookId = Guid.NewGuid();
 
         // Act
-        var readingDate = ReadingDate.Create(date, bookId);
+        var readingDate = ReadingDate.Create(date, 4, bookId);
 
         // Assert
         readingDate.Date.Should().Be(date);

--- a/tests/Persistence.Integration.Tests/Integration/Repositories/BookRepositoryTests.cs
+++ b/tests/Persistence.Integration.Tests/Integration/Repositories/BookRepositoryTests.cs
@@ -58,8 +58,8 @@ public sealed class BookRepositoryTests(IntegrationTestWebAppFactory factory) : 
     {
         // Arrange
         var book = Book.Create("X-Men", "Uncanny X-Men", "9780785134567");
-        book.AddReadingDate(DateTime.UtcNow);
-        book.AddReadingDate(DateTime.UtcNow.AddDays(-30));
+        book.AddReadingDate(DateTime.UtcNow, 4);
+        book.AddReadingDate(DateTime.UtcNow.AddDays(-30), 3);
         BookRepository.Add(book);
         await UnitOfWork.SaveChangesAsync(CancellationToken.None);
 
@@ -115,7 +115,7 @@ public sealed class BookRepositoryTests(IntegrationTestWebAppFactory factory) : 
         await UnitOfWork.SaveChangesAsync(CancellationToken.None);
 
         // Act
-        book.Update("Avengers", "New Avengers", "9780785167890", 2, "http://example.com/image.jpg", 4);
+        book.Update("Avengers", "New Avengers", "9780785167890", 2, "http://example.com/image.jpg");
         BookRepository.Update(book);
         await UnitOfWork.SaveChangesAsync(CancellationToken.None);
 
@@ -126,7 +126,6 @@ public sealed class BookRepositoryTests(IntegrationTestWebAppFactory factory) : 
         savedBook.Title.Should().Be("New Avengers");
         savedBook.VolumeNumber.Should().Be(2);
         savedBook.ImageLink.Should().Be("http://example.com/image.jpg");
-        savedBook.Rating.Should().Be(4);
     }
 
     [Fact]
@@ -211,10 +210,10 @@ public sealed class BookRepositoryTests(IntegrationTestWebAppFactory factory) : 
     {
         // Arrange
         var book1 = Book.Create("Fantastic Four", "Fantastic Four Vol 1", "9780785195678");
-        book1.AddReadingDate(DateTime.UtcNow);
+        book1.AddReadingDate(DateTime.UtcNow, 4);
         var book2 = Book.Create("Guardians of the Galaxy", "Guardians Vol 1", "9780785196789");
-        book2.AddReadingDate(DateTime.UtcNow);
-        book2.AddReadingDate(DateTime.UtcNow.AddDays(-10));
+        book2.AddReadingDate(DateTime.UtcNow, 5);
+        book2.AddReadingDate(DateTime.UtcNow.AddDays(-10), 3);
         BookRepository.Add(book1);
         BookRepository.Add(book2);
         await UnitOfWork.SaveChangesAsync(CancellationToken.None);
@@ -388,7 +387,7 @@ public sealed class BookRepositoryTests(IntegrationTestWebAppFactory factory) : 
     {
         // Arrange
         var publishDate = new DateOnly(2023, 6, 15);
-        var book = Book.Create("Saga", "Saga Vol 1", "9781607066019", 1, "", 0,
+        var book = Book.Create("Saga", "Saga Vol 1", "9781607066019", 1, "",
             "Brian K. Vaughan, Fiona Staples", "Image Comics", publishDate, 160);
 
         // Act
@@ -409,14 +408,14 @@ public sealed class BookRepositoryTests(IntegrationTestWebAppFactory factory) : 
     {
         // Arrange
         var originalPublishDate = new DateOnly(2023, 6, 15);
-        var book = Book.Create("Saga", "Saga Vol 1", "9781607066927", 1, "", 0,
+        var book = Book.Create("Saga", "Saga Vol 1", "9781607066927", 1, "",
             "Brian K. Vaughan", "Image Comics", originalPublishDate, 160);
         BookRepository.Add(book);
         await UnitOfWork.SaveChangesAsync(CancellationToken.None);
 
         // Act
         var updatedPublishDate = new DateOnly(2024, 1, 10);
-        book.Update("Saga", "Saga Vol 2", "9781607066927", 2, "http://example.com/saga2.jpg", 5,
+        book.Update("Saga", "Saga Vol 2", "9781607066927", 2, "http://example.com/saga2.jpg",
             "Brian K. Vaughan, Fiona Staples", "Image Comics, DC Comics", updatedPublishDate, 240);
         BookRepository.Update(book);
         await UnitOfWork.SaveChangesAsync(CancellationToken.None);

--- a/tests/Web.Tests/Services/BooksServiceTests.cs
+++ b/tests/Web.Tests/Services/BooksServiceTests.cs
@@ -1,6 +1,8 @@
 using Application.Abstractions.Messaging;
+using Application.Books.AddReadingDate;
 using Application.Books.Create;
 using Application.Books.Delete;
+using Application.Books.DeleteReadingDate;
 using Application.Books.GetById;
 using Application.Books.List;
 using Application.Books.Update;
@@ -21,6 +23,8 @@ public sealed class BooksServiceTests
     private readonly ICommandHandler<CreateBookCommand, Book> _createBookHandler;
     private readonly ICommandHandler<UpdateBookCommand, Book> _updateBookHandler;
     private readonly ICommandHandler<DeleteBookCommand> _deleteBookHandler;
+    private readonly ICommandHandler<AddReadingDateCommand, ReadingDate> _addReadingDateHandler;
+    private readonly ICommandHandler<DeleteReadingDateCommand> _deleteReadingDateHandler;
     private readonly BooksService _service;
 
     public BooksServiceTests()
@@ -30,13 +34,17 @@ public sealed class BooksServiceTests
         _createBookHandler = Substitute.For<ICommandHandler<CreateBookCommand, Book>>();
         _updateBookHandler = Substitute.For<ICommandHandler<UpdateBookCommand, Book>>();
         _deleteBookHandler = Substitute.For<ICommandHandler<DeleteBookCommand>>();
+        _addReadingDateHandler = Substitute.For<ICommandHandler<AddReadingDateCommand, ReadingDate>>();
+        _deleteReadingDateHandler = Substitute.For<ICommandHandler<DeleteReadingDateCommand>>();
 
         _service = new BooksService(
             _getBookByIdHandler,
             _getBooksHandler,
             _createBookHandler,
             _updateBookHandler,
-            _deleteBookHandler);
+            _deleteBookHandler,
+            _addReadingDateHandler,
+            _deleteReadingDateHandler);
     }
 
     #region GetById Tests
@@ -196,7 +204,7 @@ public sealed class BooksServiceTests
         const string imageLink = "https://example.com/cover.jpg";
         const int rating = 4;
         var request = new CreateBookRequest(series, title, isbn, volumeNumber, imageLink, rating);
-        var book = Book.Create(series, title, isbn, volumeNumber, imageLink, rating);
+        var book = Book.Create(series, title, isbn, volumeNumber, imageLink);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
@@ -227,7 +235,7 @@ public sealed class BooksServiceTests
         const string imageLink = "https://example.com/spiderman.jpg";
         const int rating = 5;
         var request = new CreateBookRequest(series, title, isbn, volumeNumber, imageLink, rating);
-        var expectedBook = Book.Create(series, title, isbn, volumeNumber, imageLink, rating);
+        var expectedBook = Book.Create(series, title, isbn, volumeNumber, imageLink);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(expectedBook);
 
@@ -243,7 +251,6 @@ public sealed class BooksServiceTests
         result.Value.ISBN.Should().Be(isbn);
         result.Value.VolumeNumber.Should().Be(volumeNumber);
         result.Value.ImageLink.Should().Be(imageLink);
-        result.Value.Rating.Should().Be(rating);
     }
 
     [Fact]
@@ -276,7 +283,7 @@ public sealed class BooksServiceTests
         const string imageLink = "https://example.com/cover.jpg";
         const int rating = 4;
         var request = new CreateBookRequest(series, title, isbn, volumeNumber, imageLink, rating);
-        var book = Book.Create(series, title, isbn, volumeNumber, imageLink, rating);
+        var book = Book.Create(series, title, isbn, volumeNumber, imageLink);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
@@ -315,7 +322,7 @@ public sealed class BooksServiceTests
         var publishDate = new DateOnly(2012, 10, 10);
         const int numberOfPages = 160;
         var request = new CreateBookRequest(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
-        var book = Book.Create(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+        var book = Book.Create(series, title, isbn, volumeNumber, imageLink, authors, publishers, publishDate, numberOfPages);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
@@ -354,7 +361,7 @@ public sealed class BooksServiceTests
         var publishDate = new DateOnly(1987, 9, 1);
         const int numberOfPages = 320;
         var request = new CreateBookRequest(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
-        var expectedBook = Book.Create(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+        var expectedBook = Book.Create(series, title, isbn, volumeNumber, imageLink, authors, publishers, publishDate, numberOfPages);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(expectedBook);
 
@@ -370,7 +377,6 @@ public sealed class BooksServiceTests
         result.Value.ISBN.Should().Be(isbn);
         result.Value.VolumeNumber.Should().Be(volumeNumber);
         result.Value.ImageLink.Should().Be(imageLink);
-        result.Value.Rating.Should().Be(rating);
         result.Value.Authors.Should().Be(authors);
         result.Value.Publishers.Should().Be(publishers);
         result.Value.PublishDate.Should().Be(publishDate);
@@ -384,7 +390,7 @@ public sealed class BooksServiceTests
         using var cts = new CancellationTokenSource();
         var publishDate = new DateOnly(2020, 1, 1);
         var request = new CreateBookRequest("Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 100);
-        var book = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 100);
+        var book = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", "Author", "Publisher", publishDate, 100);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
@@ -407,7 +413,7 @@ public sealed class BooksServiceTests
         const string authors = "Unknown Author";
         const string publishers = "Unknown Publisher";
         var request = new CreateBookRequest(series, title, isbn, 1, "", 0, authors, publishers, null, null);
-        var book = Book.Create(series, title, isbn, 1, "", 0, authors, publishers, null, null);
+        var book = Book.Create(series, title, isbn, 1, "", authors, publishers, null, null);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
@@ -430,7 +436,7 @@ public sealed class BooksServiceTests
     {
         // Arrange
         var request = new CreateBookRequest("Series", "Title", "978-3-16-148410-0");
-        var book = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", 0, "", "", null, null);
+        var book = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", "", "", null, null);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
@@ -453,7 +459,7 @@ public sealed class BooksServiceTests
         const string authors = "Stan Lee, Jack Kirby, Steve Ditko";
         const string publishers = "Marvel Comics, Timely Comics";
         var request = new CreateBookRequest("Marvel", "Fantastic Four", "978-3-16-148410-0", 1, "", 0, authors, publishers);
-        var book = Book.Create("Marvel", "Fantastic Four", "978-3-16-148410-0", 1, "", 0, authors, publishers, null, null);
+        var book = Book.Create("Marvel", "Fantastic Four", "978-3-16-148410-0", 1, "", authors, publishers, null, null);
         _createBookHandler.Handle(Arg.Any<CreateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
@@ -483,13 +489,12 @@ public sealed class BooksServiceTests
         const string isbn = "978-1-582406-72-1";
         const int volumeNumber = 1;
         const string imageLink = "https://example.com/twd.jpg";
-        const int rating = 5;
         const string authors = "Robert Kirkman, Tony Moore";
         const string publishers = "Image Comics";
         var publishDate = new DateOnly(2004, 10, 1);
         const int numberOfPages = 144;
-        var request = new UpdateBookRequest(bookId.ToString(), series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
-        var book = Book.Create(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+        var request = new UpdateBookRequest(bookId.ToString(), series, title, isbn, volumeNumber, imageLink, authors, publishers, publishDate, numberOfPages);
+        var book = Book.Create(series, title, isbn, volumeNumber, imageLink, authors, publishers, publishDate, numberOfPages);
         _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
@@ -506,7 +511,6 @@ public sealed class BooksServiceTests
                 c.ISBN == isbn &&
                 c.VolumeNumber == volumeNumber &&
                 c.ImageLink == imageLink &&
-                c.Rating == rating &&
                 c.Authors == authors &&
                 c.Publishers == publishers &&
                 c.PublishDate == publishDate &&
@@ -524,13 +528,12 @@ public sealed class BooksServiceTests
         const string isbn = "978-1-56389-980-9";
         const int volumeNumber = 1;
         const string imageLink = "https://example.com/ytlm.jpg";
-        const int rating = 5;
         const string authors = "Brian K. Vaughan, Pia Guerra";
         const string publishers = "Vertigo";
         var publishDate = new DateOnly(2003, 4, 1);
         const int numberOfPages = 128;
-        var request = new UpdateBookRequest(bookId.ToString(), series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
-        var expectedBook = Book.Create(series, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+        var request = new UpdateBookRequest(bookId.ToString(), series, title, isbn, volumeNumber, imageLink, authors, publishers, publishDate, numberOfPages);
+        var expectedBook = Book.Create(series, title, isbn, volumeNumber, imageLink, authors, publishers, publishDate, numberOfPages);
         _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(expectedBook);
 
@@ -556,8 +559,8 @@ public sealed class BooksServiceTests
         var bookId = Guid.CreateVersion7();
         using var cts = new CancellationTokenSource();
         var publishDate = new DateOnly(2020, 5, 15);
-        var request = new UpdateBookRequest(bookId.ToString(), "Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 200);
-        var book = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 200);
+        var request = new UpdateBookRequest(bookId.ToString(), "Series", "Title", "978-3-16-148410-0", 1, "", "Author", "Publisher", publishDate, 200);
+        var book = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", "Author", "Publisher", publishDate, 200);
         _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
@@ -576,7 +579,7 @@ public sealed class BooksServiceTests
         // Arrange
         string? id = null;
         var publishDate = new DateOnly(2020, 1, 1);
-        var request = new UpdateBookRequest(id, "Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 100);
+        var request = new UpdateBookRequest(id, "Series", "Title", "978-3-16-148410-0", 1, "", "Author", "Publisher", publishDate, 100);
 
         // Act
         var result = await _service.Update(request);
@@ -593,7 +596,7 @@ public sealed class BooksServiceTests
         // Arrange
         const string id = "not-a-valid-guid";
         var publishDate = new DateOnly(2020, 1, 1);
-        var request = new UpdateBookRequest(id, "Series", "Title", "978-3-16-148410-0", 1, "", 0, "Author", "Publisher", publishDate, 100);
+        var request = new UpdateBookRequest(id, "Series", "Title", "978-3-16-148410-0", 1, "", "Author", "Publisher", publishDate, 100);
 
         // Act
         var result = await _service.Update(request);
@@ -609,8 +612,8 @@ public sealed class BooksServiceTests
     {
         // Arrange
         var bookId = Guid.CreateVersion7();
-        var request = new UpdateBookRequest(bookId.ToString(), "Series", "Title", "978-3-16-148410-0", 1, "", 0);
-        var book = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", 0, "", "", null, null);
+        var request = new UpdateBookRequest(bookId.ToString(), "Series", "Title", "978-3-16-148410-0", 1, "");
+        var book = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", "", "", null, null);
         _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
@@ -634,8 +637,8 @@ public sealed class BooksServiceTests
         // Arrange
         var bookId = Guid.CreateVersion7();
         var newPublishDate = new DateOnly(2021, 6, 15);
-        var request = new UpdateBookRequest(bookId.ToString(), "Series", "Title", "978-3-16-148410-0", 1, "", 0, "New Author", "New Publisher", newPublishDate, 250);
-        var book = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", 0, "New Author", "New Publisher", newPublishDate, 250);
+        var request = new UpdateBookRequest(bookId.ToString(), "Series", "Title", "978-3-16-148410-0", 1, "", "New Author", "New Publisher", newPublishDate, 250);
+        var book = Book.Create("Series", "Title", "978-3-16-148410-0", 1, "", "New Author", "New Publisher", newPublishDate, 250);
         _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
@@ -663,9 +666,8 @@ public sealed class BooksServiceTests
         const string isbn = "978-3-16-148410-0";
         const int volumeNumber = 7;
         const string imageLink = "https://example.com/updated.jpg";
-        const int rating = 3;
-        var request = new UpdateBookRequest(bookId.ToString(), series, title, isbn, volumeNumber, imageLink, rating);
-        var book = Book.Create(series, title, isbn, volumeNumber, imageLink, rating);
+        var request = new UpdateBookRequest(bookId.ToString(), series, title, isbn, volumeNumber, imageLink);
+        var book = Book.Create(series, title, isbn, volumeNumber, imageLink);
         _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(book);
 
@@ -681,8 +683,7 @@ public sealed class BooksServiceTests
                 c.Title == title &&
                 c.ISBN == isbn &&
                 c.VolumeNumber == volumeNumber &&
-                c.ImageLink == imageLink &&
-                c.Rating == rating),
+                c.ImageLink == imageLink),
             Arg.Any<CancellationToken>());
     }
 
@@ -696,9 +697,8 @@ public sealed class BooksServiceTests
         const string isbn = "978-3-16-148410-0";
         const int volumeNumber = 15;
         const string imageLink = "https://example.com/batman.jpg";
-        const int rating = 5;
-        var request = new UpdateBookRequest(bookId.ToString(), series, title, isbn, volumeNumber, imageLink, rating);
-        var expectedBook = Book.Create(series, title, isbn, volumeNumber, imageLink, rating);
+        var request = new UpdateBookRequest(bookId.ToString(), series, title, isbn, volumeNumber, imageLink);
+        var expectedBook = Book.Create(series, title, isbn, volumeNumber, imageLink);
         _updateBookHandler.Handle(Arg.Any<UpdateBookCommand>(), Arg.Any<CancellationToken>())
             .Returns(expectedBook);
 
@@ -712,7 +712,6 @@ public sealed class BooksServiceTests
         result.Value.Serie.Should().Be(series);
         result.Value.Title.Should().Be(title);
         result.Value.VolumeNumber.Should().Be(volumeNumber);
-        result.Value.Rating.Should().Be(rating);
     }
 
     #endregion

--- a/tests/Web.Tests/Validators/BookUiDtoTests.cs
+++ b/tests/Web.Tests/Validators/BookUiDtoTests.cs
@@ -118,13 +118,12 @@ public sealed class BookUiDtoTests
         const string isbn = "978-1-401263-119-5";
         const int volumeNumber = 1;
         const string imageLink = "https://example.com/batman.jpg";
-        const int rating = 5;
         const string authors = "Frank Miller";
         const string publishers = "DC Comics";
         var publishDate = new DateOnly(1986, 2, 1);
         const int numberOfPages = 224;
 
-        var book = Book.Create(serie, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+        var book = Book.Create(serie, title, isbn, volumeNumber, imageLink, authors, publishers, publishDate, numberOfPages);
         book.CreatedOnUtc = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
         book.ModifiedOnUtc = new DateTime(2024, 1, 20, 14, 45, 0, DateTimeKind.Utc);
 
@@ -138,7 +137,7 @@ public sealed class BookUiDtoTests
         dto.ISBN.Should().Be(isbn);
         dto.VolumeNumber.Should().Be(volumeNumber);
         dto.ImageLink.Should().Be(imageLink);
-        dto.Rating.Should().Be(rating);
+        dto.Rating.Should().Be(0);
         dto.Authors.Should().Be(authors);
         dto.Publishers.Should().Be(publishers);
         dto.PublishDate.Should().Be(publishDate);
@@ -229,13 +228,12 @@ public sealed class BookUiDtoTests
         const string isbn = "978-1-582406-72-1";
         const int volumeNumber = 1;
         const string imageLink = "https://cdn.example.com/walking-dead-vol1.jpg";
-        const int rating = 4;
         const string authors = "Robert Kirkman";
         const string publishers = "Image Comics";
         var publishDate = new DateOnly(2004, 10, 1);
         const int numberOfPages = 144;
 
-        var book = Book.Create(serie, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+        var book = Book.Create(serie, title, isbn, volumeNumber, imageLink, authors, publishers, publishDate, numberOfPages);
         var createdDate = new DateTime(2023, 6, 1, 8, 0, 0, DateTimeKind.Utc);
         var modifiedDate = new DateTime(2023, 6, 15, 16, 30, 0, DateTimeKind.Utc);
         book.CreatedOnUtc = createdDate;
@@ -251,7 +249,7 @@ public sealed class BookUiDtoTests
         dto.ISBN.Should().Be(isbn);
         dto.VolumeNumber.Should().Be(volumeNumber);
         dto.ImageLink.Should().Be(imageLink);
-        dto.Rating.Should().Be(rating);
+        dto.Rating.Should().Be(0);
         dto.Authors.Should().Be(authors);
         dto.Publishers.Should().Be(publishers);
         dto.PublishDate.Should().Be(publishDate);
@@ -335,7 +333,7 @@ public sealed class BookUiDtoTests
     {
         // Arrange
         const string authors = "Stan Lee, Jack Kirby, Steve Ditko";
-        var book = Book.Create("Marvel", "The Avengers", "978-0-785-12345-6", 1, "", 0, authors, "", null, null);
+        var book = Book.Create("Marvel", "The Avengers", "978-0-785-12345-6", 1, "", authors, "", null, null);
 
         // Act
         var dto = BookUiDto.Convert(book);
@@ -349,7 +347,7 @@ public sealed class BookUiDtoTests
     {
         // Arrange
         const string publishers = "Marvel Comics, DC Comics";
-        var book = Book.Create("Crossover", "JLA/Avengers", "978-0-785-11234-5", 1, "", 0, "", publishers, null, null);
+        var book = Book.Create("Crossover", "JLA/Avengers", "978-0-785-11234-5", 1, "", "", publishers, null, null);
 
         // Act
         var dto = BookUiDto.Convert(book);
@@ -363,7 +361,7 @@ public sealed class BookUiDtoTests
     {
         // Arrange
         var publishDate = new DateOnly(1962, 8, 1); // Amazing Fantasy #15
-        var book = Book.Create("Amazing Fantasy", "Spider-Man's First Appearance", "N/A", 15, "", 0, "Stan Lee, Steve Ditko", "Marvel Comics", publishDate, 11);
+        var book = Book.Create("Amazing Fantasy", "Spider-Man's First Appearance", "N/A", 15, "", "Stan Lee, Steve Ditko", "Marvel Comics", publishDate, 11);
 
         // Act
         var dto = BookUiDto.Convert(book);
@@ -376,7 +374,7 @@ public sealed class BookUiDtoTests
     public void Convert_ShouldHandleNullPublishDate()
     {
         // Arrange
-        var book = Book.Create("Unknown", "Mystery Comic", "ISBN", 1, "", 0, "", "", null, null);
+        var book = Book.Create("Unknown", "Mystery Comic", "ISBN", 1, "", "", "", null, null);
 
         // Act
         var dto = BookUiDto.Convert(book);
@@ -390,7 +388,7 @@ public sealed class BookUiDtoTests
     {
         // Arrange
         const int numberOfPages = 320;
-        var book = Book.Create("Watchmen", "Watchmen", "978-0-930289-23-2", 1, "", 0, "Alan Moore", "DC Comics", new DateOnly(1987, 9, 1), numberOfPages);
+        var book = Book.Create("Watchmen", "Watchmen", "978-0-930289-23-2", 1, "", "Alan Moore", "DC Comics", new DateOnly(1987, 9, 1), numberOfPages);
 
         // Act
         var dto = BookUiDto.Convert(book);
@@ -416,7 +414,7 @@ public sealed class BookUiDtoTests
     public void Convert_ShouldHandleEmptyAuthorsAndPublishers()
     {
         // Arrange
-        var book = Book.Create("Series", "Title", "ISBN", 1, "", 0, "", "", null, null);
+        var book = Book.Create("Series", "Title", "ISBN", 1, "", "", "", null, null);
 
         // Act
         var dto = BookUiDto.Convert(book);
@@ -435,13 +433,12 @@ public sealed class BookUiDtoTests
         const string isbn = "978-1-60706-601-9";
         const int volumeNumber = 1;
         const string imageLink = "https://cdn.example.com/saga-vol1.jpg";
-        const int rating = 5;
         const string authors = "Brian K. Vaughan, Fiona Staples";
         const string publishers = "Image Comics";
         var publishDate = new DateOnly(2012, 10, 10);
         const int numberOfPages = 160;
 
-        var book = Book.Create(serie, title, isbn, volumeNumber, imageLink, rating, authors, publishers, publishDate, numberOfPages);
+        var book = Book.Create(serie, title, isbn, volumeNumber, imageLink, authors, publishers, publishDate, numberOfPages);
 
         // Act
         var dto = BookUiDto.Convert(book);
@@ -452,7 +449,7 @@ public sealed class BookUiDtoTests
         dto.ISBN.Should().Be(isbn);
         dto.VolumeNumber.Should().Be(volumeNumber);
         dto.ImageLink.Should().Be(imageLink);
-        dto.Rating.Should().Be(rating);
+        dto.Rating.Should().Be(0);
         dto.Authors.Should().Be(authors);
         dto.Publishers.Should().Be(publishers);
         dto.PublishDate.Should().Be(publishDate);

--- a/tests/Web.Tests/Validators/BookValidatorTests.cs
+++ b/tests/Web.Tests/Validators/BookValidatorTests.cs
@@ -24,7 +24,8 @@ public sealed class BookValidatorTests
             Title = string.Empty,
             ISBN = "0306406152",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -45,7 +46,8 @@ public sealed class BookValidatorTests
             Title = new string('A', 201),
             ISBN = "0306406152",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -66,7 +68,8 @@ public sealed class BookValidatorTests
             Title = new string('A', 200),
             ISBN = "0306406152",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -85,7 +88,8 @@ public sealed class BookValidatorTests
             Title = "Valid Title",
             ISBN = "0306406152",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -108,7 +112,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = string.Empty,
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -129,7 +134,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = new string('1', 21),
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -149,7 +155,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "invalid",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -169,7 +176,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "0306406152",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -188,7 +196,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "9780306406157",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -207,7 +216,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "043942089X",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -226,7 +236,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "978-0-306-40615-7",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -249,7 +260,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "0306406152",
             Serie = string.Empty,
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -270,7 +282,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "0306406152",
             Serie = new string('A', 201),
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -291,7 +304,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "0306406152",
             Serie = new string('A', 200),
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -310,7 +324,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "0306406152",
             Serie = "Valid Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -333,7 +348,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "0306406152",
             Serie = "Test Serie",
-            VolumeNumber = 0
+            VolumeNumber = 0,
+            Rating = 1
         };
 
         // Act
@@ -375,7 +391,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "0306406152",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -394,7 +411,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "0306406152",
             Serie = "Test Serie",
-            VolumeNumber = 999
+            VolumeNumber = 999,
+            Rating = 1
         };
 
         // Act
@@ -440,7 +458,8 @@ public sealed class BookValidatorTests
             ISBN = "0306406152",
             Serie = "Test Serie",
             VolumeNumber = 1,
-            ImageLink = string.Empty
+            ImageLink = string.Empty,
+            Rating = 1
         };
 
         // Act
@@ -460,7 +479,8 @@ public sealed class BookValidatorTests
             ISBN = "0306406152",
             Serie = "Test Serie",
             VolumeNumber = 1,
-            ImageLink = new string('A', 500)
+            ImageLink = new string('A', 500),
+            Rating = 1
         };
 
         // Act
@@ -480,7 +500,8 @@ public sealed class BookValidatorTests
             ISBN = "0306406152",
             Serie = "Test Serie",
             VolumeNumber = 1,
-            ImageLink = "https://example.com/image.jpg"
+            ImageLink = "https://example.com/image.jpg",
+            Rating = 1
         };
 
         // Act
@@ -518,7 +539,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "0306406152",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -538,7 +560,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "0306406152",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -558,7 +581,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "0306406152",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -578,7 +602,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "0306406152",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -597,7 +622,8 @@ public sealed class BookValidatorTests
             Title = string.Empty,
             ISBN = "0306406152",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -617,7 +643,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "invalid",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -637,7 +664,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "0306406152",
             Serie = string.Empty,
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -657,7 +685,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "0306406152",
             Serie = "Test Serie",
-            VolumeNumber = 0
+            VolumeNumber = 0,
+            Rating = 1
         };
 
         // Act
@@ -699,7 +728,8 @@ public sealed class BookValidatorTests
             ISBN = "0306406152",
             Serie = "Test Serie",
             VolumeNumber = 1,
-            ImageLink = string.Empty
+            ImageLink = string.Empty,
+            Rating = 1
         };
 
         // Act
@@ -722,7 +752,8 @@ public sealed class BookValidatorTests
             Title = string.Empty,
             ISBN = string.Empty,
             Serie = string.Empty,
-            VolumeNumber = 0
+            VolumeNumber = 0,
+            Rating = 1
         };
 
         // Act
@@ -746,7 +777,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = string.Empty,
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -793,7 +825,8 @@ public sealed class BookValidatorTests
             ISBN = "0306406152",
             Serie = "Test Serie",
             VolumeNumber = 1,
-            Authors = new string('A', 200)
+            Authors = new string('A', 200),
+            Rating = 1
         };
 
         // Act
@@ -813,7 +846,8 @@ public sealed class BookValidatorTests
             ISBN = "0306406152",
             Serie = "Test Serie",
             VolumeNumber = 1,
-            Authors = string.Empty
+            Authors = string.Empty,
+            Rating = 1
         };
 
         // Act
@@ -859,7 +893,8 @@ public sealed class BookValidatorTests
             ISBN = "0306406152",
             Serie = "Test Serie",
             VolumeNumber = 1,
-            Publishers = new string('A', 200)
+            Publishers = new string('A', 200),
+            Rating = 1
         };
 
         // Act
@@ -879,7 +914,8 @@ public sealed class BookValidatorTests
             ISBN = "0306406152",
             Serie = "Test Serie",
             VolumeNumber = 1,
-            Publishers = string.Empty
+            Publishers = string.Empty,
+            Rating = 1
         };
 
         // Act
@@ -947,7 +983,8 @@ public sealed class BookValidatorTests
             ISBN = "0306406152",
             Serie = "Test Serie",
             VolumeNumber = 1,
-            NumberOfPages = null
+            NumberOfPages = null,
+            Rating = 1
         };
 
         // Act
@@ -967,7 +1004,8 @@ public sealed class BookValidatorTests
             ISBN = "0306406152",
             Serie = "Test Serie",
             VolumeNumber = 1,
-            NumberOfPages = 160
+            NumberOfPages = 160,
+            Rating = 1
         };
 
         // Act
@@ -1013,7 +1051,8 @@ public sealed class BookValidatorTests
             ISBN = "0306406152",
             Serie = "Test Serie",
             VolumeNumber = 1,
-            PublishDate = null
+            PublishDate = null,
+            Rating = 1
         };
 
         // Act
@@ -1033,7 +1072,8 @@ public sealed class BookValidatorTests
             ISBN = "0306406152",
             Serie = "Test Serie",
             VolumeNumber = 1,
-            PublishDate = DateOnly.FromDateTime(DateTime.UtcNow)
+            PublishDate = DateOnly.FromDateTime(DateTime.UtcNow),
+            Rating = 1
         };
 
         // Act
@@ -1053,7 +1093,8 @@ public sealed class BookValidatorTests
             ISBN = "0306406152",
             Serie = "Test Serie",
             VolumeNumber = 1,
-            PublishDate = new DateOnly(1986, 2, 1)
+            PublishDate = new DateOnly(1986, 2, 1),
+            Rating = 1
         };
 
         // Act
@@ -1077,7 +1118,8 @@ public sealed class BookValidatorTests
             ISBN = "978-1401263119",
             Serie = "Batman",
             VolumeNumber = 1,
-            ImageLink = "https://example.com/image.jpg"
+            ImageLink = "https://example.com/image.jpg",
+            Rating = 1
         };
 
         // Act
@@ -1097,7 +1139,8 @@ public sealed class BookValidatorTests
             Title = "Ñoño's Ädventure! & Friends",
             ISBN = "0306406152",
             Serie = "Test Serie",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -1116,7 +1159,8 @@ public sealed class BookValidatorTests
             Title = "Test Title",
             ISBN = "0306406152",
             Serie = "Série écrite en français",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act
@@ -1135,7 +1179,8 @@ public sealed class BookValidatorTests
             Title = "A",
             ISBN = "0306406152",
             Serie = "B",
-            VolumeNumber = 1
+            VolumeNumber = 1,
+            Rating = 1
         };
 
         // Act


### PR DESCRIPTION
Migrated rating from Book to ReadingDate to support multiple readings and ratings per book. Updated domain model, database schema, application logic, service layer, UI components, and tests. Added commands and handlers for adding/deleting reading dates. UI now displays ratings per reading date and allows managing reading history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added reading history feature allowing users to log multiple reading sessions per book with individual ratings for each session.
  * Added ability to add and delete reading date entries from the book detail page.
  * Reading history now displays all recorded reading dates with their corresponding ratings.

* **Changes**
  * Book rating system redesigned: ratings are now associated with individual reading sessions rather than stored at the book level.
  * Book detail page now displays the most recent reading date rating and a complete reading history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->