### PR TITLE
feat: Enforce rating validation (1-5) for book creation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,7 +19,8 @@
       "Bash(git diff:*)",
       "Bash(git log:*)",
       "Bash(git add:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "WebFetch(domain:mudblazor.com)"
     ]
   }
 }

--- a/Application/Books/Create/CreateBookCommandHandler.cs
+++ b/Application/Books/Create/CreateBookCommandHandler.cs
@@ -25,6 +25,12 @@ public sealed class CreateBookCommandHandler(IBookRepository bookRepository, IUn
             return BooksError.InvalidISBN;
         }
 
+        // Validate rating range
+        if (request.Rating < 1 || request.Rating > 5)
+        {
+            return BooksError.InvalidRating;
+        }
+
         var normalizedIsbn = IsbnHelper.NormalizeIsbn(request.ISBN);
 
         // Check if a book with the same ISBN doesn't already exist

--- a/Domain/Books/BooksError.cs
+++ b/Domain/Books/BooksError.cs
@@ -9,6 +9,7 @@ public static class BooksError
     public static readonly TError Duplicate = new("BOK409", "A book is already created with this ISBN");
     public static readonly TError ValidationError = new("BOK504", "The parameters were not validated");
     public static readonly TError InvalidISBN = new("BOK505", "The ISBN format is invalid");
+    public static readonly TError InvalidRating = new("BOK506", "The rating must be between 1 and 5");
     public static readonly TError DialogError = new("BOK701", "Dialog initialisation error");
     public static readonly TError DialogCanceled = new("BOK702", "Dialog canceled by user");
     public static readonly TError ScanError = new("BOK801", "ISBN scanning failed");

--- a/Web/Components/Pages/Books/BookForm.razor
+++ b/Web/Components/Pages/Books/BookForm.razor
@@ -22,8 +22,23 @@
                 @if (ShowRating)
                 {
                     <MudPaper Class="pa-3 rounded-lg" Elevation="0" Style="background: var(--mud-palette-background-gray);">
-                        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-1">Your Rating</MudText>
-                        <MudRating @bind-SelectedValue="Model.Rating" MaxValue="5" Size="Size.Medium" />
+                        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">Your Rating</MudText>
+                        <MudToggleGroup T="int"
+                                        Value="Model.Rating"
+                                        ValueChanged="@((int v) => { if (v != 0) Model.Rating = v; })"
+                                        For="@(() => Model.Rating)"
+                                        SelectionMode="SelectionMode.SingleSelection"
+                                        Color="Color.Warning"
+                                        Rounded="true">
+                            @for (var i = 1; i <= 5; i++)
+                            {
+                                var rating = i;
+                                <MudToggleItem Value="@rating">
+                                    <MudIcon Icon="@Icons.Material.Filled.Star" Size="Size.Small" Class="mr-1" />
+                                    @rating
+                                </MudToggleItem>
+                            }
+                        </MudToggleGroup>
                     </MudPaper>
                 }
             </div>

--- a/tests/Application.UnitTests/Books/CreateBookCommandHandlerTests.cs
+++ b/tests/Application.UnitTests/Books/CreateBookCommandHandlerTests.cs
@@ -186,7 +186,7 @@ public class CreateBookCommandHandlerTests
     public async Task Handle_Should_ReturnSuccess_WithISBN10Format()
     {
         // Arrange
-        var isbn10Command = new CreateBookCommand("Serie", "Title", "0-306-40615-2", 1, "");
+        var isbn10Command = new CreateBookCommand("Serie", "Title", "0-306-40615-2", 1, "", 1);
         var normalizedIsbn = IsbnHelper.NormalizeIsbn(isbn10Command.ISBN);
         _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>()).Returns((Book?)null);
 
@@ -205,7 +205,7 @@ public class CreateBookCommandHandlerTests
     public async Task Handle_Should_ReturnSuccess_WithISBN13Format()
     {
         // Arrange
-        var isbn13Command = new CreateBookCommand("Serie", "Title", "978-0-306-40615-7", 1, "");
+        var isbn13Command = new CreateBookCommand("Serie", "Title", "978-0-306-40615-7", 1, "", 1);
         var normalizedIsbn = IsbnHelper.NormalizeIsbn(isbn13Command.ISBN);
         _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>()).Returns((Book?)null);
 
@@ -224,7 +224,7 @@ public class CreateBookCommandHandlerTests
     public async Task Handle_Should_CreateBookWithDefaultValues_WhenOptionalParametersNotProvided()
     {
         // Arrange
-        var minimalCommand = new CreateBookCommand("Serie", "Title", "978-3-16-148410-0");
+        var minimalCommand = new CreateBookCommand("Serie", "Title", "978-3-16-148410-0", Rating: 1);
         var normalizedIsbn = IsbnHelper.NormalizeIsbn(minimalCommand.ISBN);
         _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>()).Returns((Book?)null);
 
@@ -236,8 +236,6 @@ public class CreateBookCommandHandlerTests
         Guard.Against.Null(result.Value);
         result.Value.VolumeNumber.Should().Be(1);
         result.Value.ImageLink.Should().Be(string.Empty);
-        result.Value.ReadingDates.Should().HaveCount(1);
-        result.Value.ReadingDates[0].Rating.Should().Be(0);
         _bookRepositoryMock.Received(1).Add(Arg.Any<Book>());
         await _unitOfWorkMock.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
     }
@@ -261,7 +259,7 @@ public class CreateBookCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_Should_AlwaysAddReadingDate_EvenWhenRatingIsZero()
+    public async Task Handle_Should_ReturnInvalidRating_WhenRatingIsZero()
     {
         // Arrange
         var commandWithoutRating = new CreateBookCommand("Serie", "Title", "978-3-16-148410-0", 1, "", 0);
@@ -272,10 +270,28 @@ public class CreateBookCommandHandlerTests
         var result = await _handler.Handle(commandWithoutRating, default);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
-        Guard.Against.Null(result.Value);
-        result.Value.ReadingDates.Should().HaveCount(1);
-        result.Value.ReadingDates[0].Rating.Should().Be(0);
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(BooksError.InvalidRating);
+        _bookRepositoryMock.Received(0).Add(Arg.Any<Book>());
+        await _unitOfWorkMock.Received(0).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_Should_ReturnInvalidRating_WhenRatingIsGreaterThanFive()
+    {
+        // Arrange
+        var commandWithHighRating = new CreateBookCommand("Serie", "Title", "978-3-16-148410-0", 1, "", 6);
+        var normalizedIsbn = IsbnHelper.NormalizeIsbn(commandWithHighRating.ISBN);
+        _bookRepositoryMock.GetByIsbnAsync(Arg.Is<string>(s => s == normalizedIsbn), Arg.Any<CancellationToken>()).Returns((Book?)null);
+
+        // Act
+        var result = await _handler.Handle(commandWithHighRating, default);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(BooksError.InvalidRating);
+        _bookRepositoryMock.Received(0).Add(Arg.Any<Book>());
+        await _unitOfWorkMock.Received(0).SaveChangesAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -348,7 +364,8 @@ public class CreateBookCommandHandlerTests
             "Watchmen",
             "978-1-4012-4525-2",
             Authors: authors,
-            Publishers: publishers
+            Publishers: publishers,
+            Rating: 1
         );
 
         var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
@@ -377,7 +394,8 @@ public class CreateBookCommandHandlerTests
             "The Walking Dead",
             "Days Gone Bye",
             "978-1-58240-619-0",
-            PublishDate: publishDate
+            PublishDate: publishDate,
+            Rating: 1
         );
 
         var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
@@ -406,7 +424,8 @@ public class CreateBookCommandHandlerTests
             "Y: The Last Man",
             "Unmanned",
             "978-1-4012-1951-2",
-            NumberOfPages: numberOfPages
+            NumberOfPages: numberOfPages,
+            Rating: 1
         );
 
         var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
@@ -432,7 +451,8 @@ public class CreateBookCommandHandlerTests
         var command = new CreateBookCommand(
             "Fables",
             "Volume 1",
-            "978-1-56389-942-3"
+            "978-1-56389-942-3",
+            Rating: 1
         );
 
         var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
@@ -460,7 +480,8 @@ public class CreateBookCommandHandlerTests
             "Unknown Title",
             "978-3-16-148410-0",
             Authors: "",
-            Publishers: ""
+            Publishers: "",
+            Rating: 1
         );
 
         var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
@@ -486,7 +507,8 @@ public class CreateBookCommandHandlerTests
             "Marvel",
             "The Avengers",
             "978-1-4012-4525-2",
-            Authors: authors
+            Authors: authors,
+            Rating: 1
         );
 
         var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
@@ -511,7 +533,8 @@ public class CreateBookCommandHandlerTests
             "Crossover",
             "JLA/Avengers",
             "978-1-4012-0331-3",
-            Publishers: publishers
+            Publishers: publishers,
+            Rating: 1
         );
 
         var normalizedIsbn = IsbnHelper.NormalizeIsbn(command.ISBN);
@@ -538,7 +561,7 @@ public class CreateBookCommandHandlerTests
             "978-1-60706-601-9",
             15,
             "",
-            0,
+            1,
             "Stan Lee, Steve Ditko",
             "Marvel Comics",
             publishDate,
@@ -570,7 +593,7 @@ public class CreateBookCommandHandlerTests
             "978-0-930289-23-2",
             1,
             "",
-            0,
+            1,
             "Alan Moore",
             "DC Comics",
             new DateOnly(1987, 9, 1),

--- a/tests/Web.Tests/Validators/BookValidatorTests.cs
+++ b/tests/Web.Tests/Validators/BookValidatorTests.cs
@@ -1106,6 +1106,116 @@ public sealed class BookValidatorTests
 
     #endregion
 
+    #region Rating Validation Tests
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenRatingIsZero()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            Rating = 0
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.PropertyName == nameof(BookUiDto.Rating));
+        result.Errors.Should().ContainSingle(e => e.ErrorMessage == "La note est obligatoire (1 à 5 étoiles).");
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenRatingIsNegative()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            Rating = -1
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.PropertyName == nameof(BookUiDto.Rating));
+        result.Errors.Should().ContainSingle(e => e.ErrorMessage == "La note est obligatoire (1 à 5 étoiles).");
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenRatingIsGreaterThanFive()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            Rating = 6
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.PropertyName == nameof(BookUiDto.Rating));
+        result.Errors.Should().ContainSingle(e => e.ErrorMessage == "La note est obligatoire (1 à 5 étoiles).");
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenRatingIsOne()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            Rating = 1
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenRatingIsFive()
+    {
+        // Arrange
+        var dto = new BookUiDto
+        {
+            Title = "Test Title",
+            ISBN = "0306406152",
+            Serie = "Test Serie",
+            VolumeNumber = 1,
+            Rating = 5
+        };
+
+        // Act
+        var result = _validator.Validate(dto);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    #endregion
+
     #region Edge Cases Tests
 
     [Fact]


### PR DESCRIPTION
Add validation to ensure book ratings are between 1 and 5 inclusive. Update backend handler and error codes, and replace the rating UI with a toggle group to prevent invalid input. Adjust and expand unit tests to cover rating validation in both command handler and validator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented rating validation to ensure all book ratings are between 1 and 5.

* **UI Improvements**
  * Redesigned the book rating input with an intuitive 5-star selection interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->