### PR TITLE
feat: Add Bedetheque as primary comic metadata provider

### DIFF
--- a/Application/Books/Update/UpdateBookCommandHandler.cs
+++ b/Application/Books/Update/UpdateBookCommandHandler.cs
@@ -27,7 +27,7 @@ public sealed class UpdateBookCommandHandler(
             return BooksError.InvalidISBN;
         }
         var normalizedIsbn = IsbnHelper.NormalizeIsbn(request.ISBN);
-     
+
         var book = await bookRepository.GetByIdAsync(request.Id);
         if (book == null)
         {

--- a/Application/ComicInfoSearch/BedethequeService.cs
+++ b/Application/ComicInfoSearch/BedethequeService.cs
@@ -13,8 +13,8 @@ public partial class BedethequeService : IBedethequeService
 {
     private static Serilog.ILogger Log => Serilog.Log.ForContext<BedethequeService>();
 
-    private const string BdUrlPrefix = "https://www.bedetheque.com/BD";
-    private const string CoversBaseUrl = "https://www.bedetheque.com/media/Couvertures/Couv_";
+    private const string BdUrlPrefix = "/BD";
+    private const string CoversBaseUrl = "/media/Couvertures/Couv_";
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IIsbnBedethequeCacheRepository _cacheRepository;

--- a/Application/ComicInfoSearch/BedethequeService.cs
+++ b/Application/ComicInfoSearch/BedethequeService.cs
@@ -1,0 +1,342 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Application.Helpers;
+using Application.Interfaces;
+using HtmlAgilityPack;
+using Microsoft.Extensions.Options;
+
+namespace Application.ComicInfoSearch;
+
+public partial class BedethequeService : IBedethequeService
+{
+    private static Serilog.ILogger Log => Serilog.Log.ForContext<BedethequeService>();
+
+    private const string BdUrlPrefix = "https://www.bedetheque.com/BD";
+    private const string CoversBaseUrl = "https://www.bedetheque.com/media/Couvertures/Couv_";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IIsbnBedethequeCacheRepository _cacheRepository;
+    private readonly BedethequeSettings _settings;
+
+    public BedethequeService(
+        IHttpClientFactory httpClientFactory,
+        IIsbnBedethequeCacheRepository cacheRepository,
+        IOptions<BedethequeSettings> settings)
+    {
+        _httpClientFactory = httpClientFactory;
+        _cacheRepository = cacheRepository;
+        _settings = settings.Value;
+    }
+
+    public async Task<BedethequeBookResult> SearchByIsbnAsync(string isbn, CancellationToken ct = default)
+    {
+        var cleanIsbn = IsbnHelper.NormalizeIsbn(isbn);
+
+        try
+        {
+            var url = await GetBedethequeUrlAsync(cleanIsbn, ct);
+            if (url is null)
+            {
+                return CreateNotFoundResult();
+            }
+
+            Log.Information("Fetching Bedetheque page: {Url}", url);
+            var html = await FetchPageAsync(url, ct);
+            if (html is null)
+            {
+                return CreateNotFoundResult();
+            }
+
+            return ParsePage(html, url);
+        }
+        catch (HttpRequestException ex)
+        {
+            Log.Error(ex, "HTTP error searching Bedetheque for ISBN: {Isbn}", cleanIsbn);
+            return CreateNotFoundResult();
+        }
+        catch (JsonException ex)
+        {
+            Log.Error(ex, "JSON parsing error for ISBN: {Isbn}", cleanIsbn);
+            return CreateNotFoundResult();
+        }
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+        {
+            Log.Error(ex, "Timeout searching Bedetheque for ISBN: {Isbn}", cleanIsbn);
+            return CreateNotFoundResult();
+        }
+    }
+
+    private async Task<string?> GetBedethequeUrlAsync(string isbn, CancellationToken ct)
+    {
+        // Check cache first
+        var cachedUrl = await _cacheRepository.GetUrlByIsbnAsync(isbn, ct);
+        if (cachedUrl is not null)
+        {
+            Log.Information("Cache hit for ISBN {Isbn}: {Url}", isbn, cachedUrl);
+            return cachedUrl;
+        }
+
+        if (string.IsNullOrWhiteSpace(_settings.SerpApiKey))
+        {
+            Log.Warning("SerpApi key is not configured, skipping Bedetheque search for ISBN {Isbn}", isbn);
+            return null;
+        }
+
+        // Call SerpApi
+        var serpUrl = BuildSerpApiUrl(isbn);
+        Log.Information("Calling SerpApi for ISBN {Isbn}", isbn);
+
+        var serpClient = _httpClientFactory.CreateClient("SerpApi");
+        var response = await serpClient.GetAsync(new Uri(serpUrl), ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            Log.Warning("SerpApi returned {StatusCode} for ISBN {Isbn}", response.StatusCode, isbn);
+            return null;
+        }
+
+        var serpResult = await response.Content.ReadFromJsonAsync<SerpApiResponse>(JsonOptions, ct);
+
+        var bdLinks = serpResult?.OrganicResults?
+            .Where(r => r.Link?.StartsWith(BdUrlPrefix, StringComparison.OrdinalIgnoreCase) == true)
+            .Select(r => r.Link!)
+            .ToList() ?? [];
+
+        if (bdLinks.Count != 1)
+        {
+            Log.Warning("Found {Count} BD links for ISBN {Isbn}, expected exactly 1 — skipping", bdLinks.Count, isbn);
+            return null;
+        }
+
+        var bdUrl = bdLinks[0];
+        await _cacheRepository.SaveAsync(isbn, bdUrl, ct);
+        Log.Information("Cached Bedetheque URL for ISBN {Isbn}: {Url}", isbn, bdUrl);
+
+        return bdUrl;
+    }
+
+    private string BuildSerpApiUrl(string isbn)
+    {
+        var query = Uri.EscapeDataString($"{isbn} site:bedetheque.com");
+        return $"{_settings.SerpApiBaseUrl}/search.json?engine=google&q={query}&location=France&google_domain=google.fr&hl=fr&gl=fr&api_key={_settings.SerpApiKey}";
+    }
+
+    private async Task<string?> FetchPageAsync(string url, CancellationToken ct)
+    {
+        var client = _httpClientFactory.CreateClient("Bedetheque");
+        var response = await client.GetAsync(new Uri(url), ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            Log.Warning("Bedetheque page returned {StatusCode} for URL: {Url}", response.StatusCode, url);
+            return null;
+        }
+
+        return await response.Content.ReadAsStringAsync(ct);
+    }
+
+    private static BedethequeBookResult ParsePage(string html, string pageUrl)
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        var title = ParseTitle(doc);
+        var serie = ParseSerie(doc);
+        var volumeNumber = ParseVolumeNumber(doc);
+        var authors = ParseAuthors(doc);
+        var publishers = ParsePublishers(doc);
+        var publishDate = ParsePublishDate(doc);
+        var numberOfPages = ParseNumberOfPages(doc);
+        var coverUrl = BuildCoverUrl(pageUrl);
+
+        Log.Information("Parsed Bedetheque page: {Serie} T{Volume} - {Title}", serie, volumeNumber, title);
+
+        return new BedethequeBookResult(
+            Title: title,
+            Serie: serie,
+            VolumeNumber: volumeNumber,
+            Authors: authors,
+            Publishers: publishers,
+            PublishDate: publishDate,
+            NumberOfPages: numberOfPages,
+            CoverUrl: coverUrl,
+            Found: !string.IsNullOrWhiteSpace(title) || !string.IsNullOrWhiteSpace(serie)
+        );
+    }
+
+    // Returns the first non-empty text node inside a <li> from infos-albums whose <label> contains the given text.
+    private static string? GetInfoAlbumFieldText(HtmlDocument doc, string labelContains)
+    {
+        var li = doc.DocumentNode.SelectSingleNode(
+            $"//ul[contains(@class,'infos-albums')]//li[label[contains(.,'{labelContains}')]]");
+
+        return li?.SelectNodes("text()")
+            ?.Select(n => HtmlEntity.DeEntitize(n.InnerText.Trim()))
+            .FirstOrDefault(t => !string.IsNullOrWhiteSpace(t));
+    }
+
+    private static string ParseTitle(HtmlDocument doc) =>
+        GetInfoAlbumFieldText(doc, "Titre") ?? string.Empty;
+
+    private static string ParseSerie(HtmlDocument doc) =>
+        GetInfoAlbumFieldText(doc, "Série") ?? string.Empty;
+
+    private static int ParseVolumeNumber(HtmlDocument doc)
+    {
+        var text = GetInfoAlbumFieldText(doc, "Tome");
+        return text is not null && int.TryParse(text, out var vol) ? vol : 1;
+    }
+
+    private static List<string> ParseAuthors(HtmlDocument doc)
+    {
+        var authors = new List<string>();
+
+        var scenarioLi = doc.DocumentNode.SelectSingleNode(
+            "//ul[contains(@class,'infos-albums')]//li[label[contains(.,'Scénario')]]");
+        var scenario = scenarioLi?.SelectSingleNode(".//a")?.InnerText.Trim();
+        if (!string.IsNullOrWhiteSpace(scenario))
+        {
+            authors.Add(HtmlEntity.DeEntitize(scenario));
+        }
+
+        var dessinLi = doc.DocumentNode.SelectSingleNode(
+            "//ul[contains(@class,'infos-albums')]//li[label[contains(.,'Dessin')]]");
+        var dessin = dessinLi?.SelectSingleNode(".//a")?.InnerText.Trim();
+        if (!string.IsNullOrWhiteSpace(dessin) && !authors.Contains(HtmlEntity.DeEntitize(dessin)))
+        {
+            authors.Add(HtmlEntity.DeEntitize(dessin));
+        }
+
+        return authors;
+    }
+
+    private static IReadOnlyList<string> ParsePublishers(HtmlDocument doc)
+    {
+        var li = doc.DocumentNode.SelectSingleNode(
+            "//ul[contains(@class,'infos-albums')]//li[label[contains(.,'diteur')]]");
+        if (li is null)
+        {
+            return [];
+        }
+
+        // Publisher is wrapped in a <span> or as a direct text node
+        var span = li.SelectSingleNode(".//span");
+        var text = span is not null
+            ? HtmlEntity.DeEntitize(span.InnerText.Trim())
+            : GetInfoAlbumFieldText(doc, "diteur");
+
+        return string.IsNullOrWhiteSpace(text) ? [] : [text];
+    }
+
+    // Matches "Parution le DD/MM/YYYY" (inside the grise span on the Dépot légal line)
+    [GeneratedRegex(@"Parution\s+le\s+(\d{2}/\d{2}/\d{4})", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex ParutionDateRegex();
+
+    // Matches "MM/YYYY" for the Dépot légal field text node
+    [GeneratedRegex(@"(\d{2})/(\d{4})", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex MonthYearRegex();
+
+    private static DateOnly? ParsePublishDate(HtmlDocument doc)
+    {
+        // The Dépot/Dépôt légal <li> — "légal" is common to both spelling variants
+        var li = doc.DocumentNode.SelectSingleNode(
+            "//ul[contains(@class,'infos-albums')]//li[label[contains(.,'gal')]]");
+        if (li is null)
+        {
+            return null;
+        }
+
+        // Strategy 1: "Parution le DD/MM/YYYY" from the <span class="grise">
+        var griseSpan = li.SelectSingleNode(".//span[contains(@class,'grise')]");
+        if (griseSpan is not null)
+        {
+            var parutionMatch = ParutionDateRegex().Match(griseSpan.InnerText);
+            if (parutionMatch.Success)
+            {
+                var parsed = PublishDateHelper.ParsePublishDate(parutionMatch.Groups[1].Value);
+                if (parsed is not null)
+                {
+                    return parsed;
+                }
+            }
+        }
+
+        // Strategy 2: "MM/YYYY" from the direct text node (e.g. "08/2014")
+        var textNode = li.SelectNodes("text()")
+            ?.Select(n => n.InnerText.Trim())
+            .FirstOrDefault(t => !string.IsNullOrWhiteSpace(t));
+
+        if (textNode is not null)
+        {
+            var mmYyyy = MonthYearRegex().Match(textNode);
+            if (mmYyyy.Success &&
+                int.TryParse(mmYyyy.Groups[1].Value, out var month) &&
+                int.TryParse(mmYyyy.Groups[2].Value, out var year) &&
+                month is >= 1 and <= 12 &&
+                year is >= 1900 and <= 2100)
+            {
+                return new DateOnly(year, month, 1);
+            }
+        }
+
+        return null;
+    }
+
+    private static int? ParseNumberOfPages(HtmlDocument doc)
+    {
+        var li = doc.DocumentNode.SelectSingleNode(
+            "//ul[contains(@class,'infos-albums')]//li[label[contains(.,'Planches')]]");
+        if (li is null)
+        {
+            return null;
+        }
+
+        var span = li.SelectSingleNode(".//span");
+        var text = span?.InnerText.Trim() ?? GetInfoAlbumFieldText(doc, "Planches");
+        return text is not null && int.TryParse(text, out var pages) ? pages : null;
+    }
+
+    [GeneratedRegex(@"-(\d+)\.html$", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex PageIdRegex();
+
+    private static Uri? BuildCoverUrl(string pageUrl)
+    {
+        // Extract the last numeric ID from the URL: /BD-...-224335.html → 224335
+        var match = PageIdRegex().Match(pageUrl);
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        return new Uri($"{CoversBaseUrl}{match.Groups[1].Value}.jpg");
+    }
+
+    private static BedethequeBookResult CreateNotFoundResult() =>
+        new(
+            Title: string.Empty,
+            Serie: string.Empty,
+            VolumeNumber: 1,
+            Authors: [],
+            Publishers: [],
+            PublishDate: null,
+            NumberOfPages: null,
+            CoverUrl: null,
+            Found: false
+        );
+
+    private static JsonSerializerOptions JsonOptions => new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    // Internal DTOs for SerpApi JSON deserialization
+    private sealed record SerpApiResponse(
+        [property: JsonPropertyName("organic_results")] IReadOnlyList<SerpApiOrganicResult>? OrganicResults
+    );
+
+    private sealed record SerpApiOrganicResult(
+        [property: JsonPropertyName("link")] string? Link
+    );
+}

--- a/Application/ComicInfoSearch/BedethequeService.cs
+++ b/Application/ComicInfoSearch/BedethequeService.cs
@@ -13,12 +13,11 @@ public partial class BedethequeService : IBedethequeService
 {
     private static Serilog.ILogger Log => Serilog.Log.ForContext<BedethequeService>();
 
-    private const string BdUrlPrefix = "https://www.bedetheque.com/BD";
-    private const string CoversBaseUrl = "https://www.bedetheque.com/media/Couvertures/Couv_";
-
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IIsbnBedethequeCacheRepository _cacheRepository;
     private readonly BedethequeSettings _settings;
+    private readonly string _bdUrlPrefix;
+    private readonly string _coversBaseUrl;
 
     public BedethequeService(
         IHttpClientFactory httpClientFactory,
@@ -28,6 +27,9 @@ public partial class BedethequeService : IBedethequeService
         _httpClientFactory = httpClientFactory;
         _cacheRepository = cacheRepository;
         _settings = settings.Value;
+        var baseUrl = _settings.BaseUrl.ToString().TrimEnd('/');
+        _bdUrlPrefix = $"{baseUrl}/BD";
+        _coversBaseUrl = $"{baseUrl}/media/Couvertures/Couv_";
     }
 
     public async Task<BedethequeBookResult> SearchByIsbnAsync(string isbn, CancellationToken ct = default)
@@ -49,7 +51,7 @@ public partial class BedethequeService : IBedethequeService
                 return CreateNotFoundResult();
             }
 
-            return ParsePage(html, url);
+            return ParsePage(html, url, _coversBaseUrl);
         }
         catch (HttpRequestException ex)
         {
@@ -100,7 +102,7 @@ public partial class BedethequeService : IBedethequeService
         var serpResult = await response.Content.ReadFromJsonAsync<SerpApiResponse>(JsonOptions, ct);
 
         var bdLinks = serpResult?.OrganicResults?
-            .Where(r => r.Link?.StartsWith(BdUrlPrefix, StringComparison.OrdinalIgnoreCase) == true)
+            .Where(r => r.Link?.StartsWith(_bdUrlPrefix, StringComparison.OrdinalIgnoreCase) == true)
             .Select(r => r.Link!)
             .ToList() ?? [];
 
@@ -137,7 +139,7 @@ public partial class BedethequeService : IBedethequeService
         return await response.Content.ReadAsStringAsync(ct);
     }
 
-    private static BedethequeBookResult ParsePage(string html, string pageUrl)
+    private static BedethequeBookResult ParsePage(string html, string pageUrl, string coversBaseUrl)
     {
         var doc = new HtmlDocument();
         doc.LoadHtml(html);
@@ -149,7 +151,7 @@ public partial class BedethequeService : IBedethequeService
         var publishers = ParsePublishers(doc);
         var publishDate = ParsePublishDate(doc);
         var numberOfPages = ParseNumberOfPages(doc);
-        var coverUrl = BuildCoverUrl(pageUrl);
+        var coverUrl = BuildCoverUrl(pageUrl, coversBaseUrl);
 
         Log.Information("Parsed Bedetheque page: {Serie} T{Volume} - {Title}", serie, volumeNumber, title);
 
@@ -301,16 +303,15 @@ public partial class BedethequeService : IBedethequeService
     [GeneratedRegex(@"-(\d+)\.html$", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
     private static partial Regex PageIdRegex();
 
-    private static Uri? BuildCoverUrl(string pageUrl)
+    private static Uri? BuildCoverUrl(string pageUrl, string coversBaseUrl)
     {
-        // Extract the last numeric ID from the URL: /BD-...-224335.html → 224335
         var match = PageIdRegex().Match(pageUrl);
         if (!match.Success)
         {
             return null;
         }
 
-        return new Uri($"{CoversBaseUrl}{match.Groups[1].Value}.jpg");
+        return new Uri($"{coversBaseUrl}{match.Groups[1].Value}.jpg");
     }
 
     private static BedethequeBookResult CreateNotFoundResult() =>

--- a/Application/ComicInfoSearch/BedethequeService.cs
+++ b/Application/ComicInfoSearch/BedethequeService.cs
@@ -13,8 +13,8 @@ public partial class BedethequeService : IBedethequeService
 {
     private static Serilog.ILogger Log => Serilog.Log.ForContext<BedethequeService>();
 
-    private const string BdUrlPrefix = "/BD";
-    private const string CoversBaseUrl = "/media/Couvertures/Couv_";
+    private const string BdUrlPrefix = "https://www.bedetheque.com/BD";
+    private const string CoversBaseUrl = "https://www.bedetheque.com/media/Couvertures/Couv_";
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IIsbnBedethequeCacheRepository _cacheRepository;

--- a/Application/ComicInfoSearch/BedethequeService.cs
+++ b/Application/ComicInfoSearch/BedethequeService.cs
@@ -38,7 +38,13 @@ public partial class BedethequeService : IBedethequeService
 
         try
         {
-            var url = await GetBedethequeUrlAsync(cleanIsbn, ct);
+            var cachedUrl = await _cacheRepository.GetUrlByIsbnAsync(cleanIsbn, ct);
+            if (cachedUrl is not null)
+            {
+                Log.Information("Cache hit for ISBN {Isbn}: {Url}", cleanIsbn, cachedUrl);
+            }
+
+            var url = cachedUrl ?? await ResolveFromSerpApiAsync(cleanIsbn, ct);
             if (url is null)
             {
                 return CreateNotFoundResult();
@@ -51,7 +57,15 @@ public partial class BedethequeService : IBedethequeService
                 return CreateNotFoundResult();
             }
 
-            return ParsePage(html, url, _coversBaseUrl);
+            var result = ParsePage(html, url, _coversBaseUrl);
+
+            if (result.Found && cachedUrl is null)
+            {
+                await _cacheRepository.SaveAsync(cleanIsbn, url, ct);
+                Log.Information("Cached Bedetheque URL for ISBN {Isbn}: {Url}", cleanIsbn, url);
+            }
+
+            return result;
         }
         catch (HttpRequestException ex)
         {
@@ -70,16 +84,8 @@ public partial class BedethequeService : IBedethequeService
         }
     }
 
-    private async Task<string?> GetBedethequeUrlAsync(string isbn, CancellationToken ct)
+    private async Task<string?> ResolveFromSerpApiAsync(string isbn, CancellationToken ct)
     {
-        // Check cache first
-        var cachedUrl = await _cacheRepository.GetUrlByIsbnAsync(isbn, ct);
-        if (cachedUrl is not null)
-        {
-            Log.Information("Cache hit for ISBN {Isbn}: {Url}", isbn, cachedUrl);
-            return cachedUrl;
-        }
-
         if (string.IsNullOrWhiteSpace(_settings.SerpApiKey))
         {
             Log.Warning("SerpApi key is not configured, skipping Bedetheque search for ISBN {Isbn}", isbn);
@@ -112,11 +118,7 @@ public partial class BedethequeService : IBedethequeService
             return null;
         }
 
-        var bdUrl = bdLinks[0];
-        await _cacheRepository.SaveAsync(isbn, bdUrl, ct);
-        Log.Information("Cached Bedetheque URL for ISBN {Isbn}: {Url}", isbn, bdUrl);
-
-        return bdUrl;
+        return bdLinks[0];
     }
 
     private string BuildSerpApiUrl(string isbn)
@@ -197,18 +199,32 @@ public partial class BedethequeService : IBedethequeService
 
         var scenarioLi = doc.DocumentNode.SelectSingleNode(
             "//ul[contains(@class,'infos-albums')]//li[label[contains(.,'Scénario')]]");
-        var scenario = scenarioLi?.SelectSingleNode(".//a")?.InnerText.Trim();
-        if (!string.IsNullOrWhiteSpace(scenario))
+        var scenarioAnchors = scenarioLi?.SelectNodes(".//a");
+        if (scenarioAnchors != null)
         {
-            authors.Add(HtmlEntity.DeEntitize(scenario));
+            foreach (var anchor in scenarioAnchors)
+            {
+                var name = HtmlEntity.DeEntitize(anchor.InnerText.Trim());
+                if (!string.IsNullOrWhiteSpace(name) && !authors.Contains(name))
+                {
+                    authors.Add(name);
+                }
+            }
         }
 
         var dessinLi = doc.DocumentNode.SelectSingleNode(
             "//ul[contains(@class,'infos-albums')]//li[label[contains(.,'Dessin')]]");
-        var dessin = dessinLi?.SelectSingleNode(".//a")?.InnerText.Trim();
-        if (!string.IsNullOrWhiteSpace(dessin) && !authors.Contains(HtmlEntity.DeEntitize(dessin)))
+        var dessinAnchors = dessinLi?.SelectNodes(".//a");
+        if (dessinAnchors != null)
         {
-            authors.Add(HtmlEntity.DeEntitize(dessin));
+            foreach (var anchor in dessinAnchors)
+            {
+                var name = HtmlEntity.DeEntitize(anchor.InnerText.Trim());
+                if (!string.IsNullOrWhiteSpace(name) && !authors.Contains(name))
+                {
+                    authors.Add(name);
+                }
+            }
         }
 
         return authors;

--- a/Application/ComicInfoSearch/BedethequeSettings.cs
+++ b/Application/ComicInfoSearch/BedethequeSettings.cs
@@ -3,7 +3,7 @@ namespace Application.ComicInfoSearch;
 public sealed class BedethequeSettings
 {
     public string SerpApiKey { get; init; } = string.Empty;
-    public Uri BaseUrl { get; init; } = new Uri("https://www.bedetheque.com");
-    public Uri SerpApiBaseUrl { get; init; } = new Uri("https://serpapi.com");
+    public required Uri BaseUrl { get; init; } 
+    public required Uri SerpApiBaseUrl { get; init; } 
 }
 

--- a/Application/ComicInfoSearch/BedethequeSettings.cs
+++ b/Application/ComicInfoSearch/BedethequeSettings.cs
@@ -1,0 +1,9 @@
+namespace Application.ComicInfoSearch;
+
+public sealed class BedethequeSettings
+{
+    public string SerpApiKey { get; init; } = string.Empty;
+    public Uri BaseUrl { get; init; } = new Uri("https://www.bedetheque.com");
+    public Uri SerpApiBaseUrl { get; init; } = new Uri("https://serpapi.com");
+}
+

--- a/Application/ComicInfoSearch/ComicSearchService.cs
+++ b/Application/ComicInfoSearch/ComicSearchService.cs
@@ -11,17 +11,20 @@ public partial class ComicSearchService : IComicSearchService
 
     private readonly IOpenLibraryService _openLibraryService;
     private readonly IGoogleBooksService _googleBooksService;
+    private readonly IBedethequeService _bedethequeService;
     private readonly ICloudinaryService _cloudinaryService;
     private readonly CloudinarySettings _cloudinarySettings;
 
     public ComicSearchService(
         IOpenLibraryService openLibraryService,
         IGoogleBooksService googleBooksService,
+        IBedethequeService bedethequeService,
         ICloudinaryService cloudinaryService,
         IOptions<CloudinarySettings> cloudinarySettings)
     {
         _openLibraryService = openLibraryService;
         _googleBooksService = googleBooksService;
+        _bedethequeService = bedethequeService;
         _cloudinaryService = cloudinaryService;
         _cloudinarySettings = cloudinarySettings.Value;
     }
@@ -35,20 +38,17 @@ public partial class ComicSearchService : IComicSearchService
 
         try
         {
+            // Try Bedetheque first
+            var bedethequeResult = await _bedethequeService.SearchByIsbnAsync(cleanIsbn, cancellationToken);
 
-
-            // Try OpenLibrary first
-            var result = await _openLibraryService.SearchByIsbnAsync(cleanIsbn, cancellationToken);
-
-            if (result.Found)
+            if (bedethequeResult.Found)
             {
-                Log.Information("Book found via OpenLibrary for ISBN {Isbn}", cleanIsbn);
-                return await MapBookResultToComicSearchResultAsync(
-                    result, cleanIsbn, cancellationToken);
+                Log.Information("Book found via Bedetheque for ISBN {Isbn}", cleanIsbn);
+                return await MapBedethequeResultAsync(bedethequeResult, cleanIsbn, cancellationToken);
             }
 
             // Fallback to Google Books
-            Log.Information("OpenLibrary returned no result for ISBN {Isbn}, trying Google Books", cleanIsbn);
+            Log.Information("Bedetheque returned no result for ISBN {Isbn}, trying Google Books", cleanIsbn);
             var googleResult = await _googleBooksService.SearchByIsbnAsync(cleanIsbn, cancellationToken);
 
             if (googleResult.Found)
@@ -56,6 +56,16 @@ public partial class ComicSearchService : IComicSearchService
                 Log.Information("Book found via Google Books for ISBN {Isbn}", cleanIsbn);
                 return await MapBookResultToComicSearchResultAsync(
                     googleResult, cleanIsbn, cancellationToken);
+            }
+
+            // Fallback to OpenLibrary
+            Log.Information("Google Books returned no result for ISBN {Isbn}, trying OpenLibrary", cleanIsbn);
+            var olResult = await _openLibraryService.SearchByIsbnAsync(cleanIsbn, cancellationToken);
+
+            if (olResult.Found)
+            {
+                Log.Information("Book found via OpenLibrary for ISBN {Isbn}", cleanIsbn);
+                return await MapBookResultToComicSearchResultAsync(olResult, cleanIsbn, cancellationToken);
             }
 
             Log.Warning("No data found for ISBN {Isbn} in any provider", cleanIsbn);
@@ -88,6 +98,36 @@ public partial class ComicSearchService : IComicSearchService
         var (serie, volumeNumber) = ParseVolumeAndSerie(rawTitle);
         var title = string.IsNullOrEmpty(subtitle) ? serie : subtitle;
         return (title, serie, volumeNumber);
+    }
+
+    private async Task<ComicSearchResult> MapBedethequeResultAsync(
+        BedethequeBookResult bedethequeResult,
+        string isbn,
+        CancellationToken cancellationToken)
+    {
+        var imageUrl = string.Empty;
+        if (bedethequeResult.CoverUrl != null)
+        {
+            imageUrl = await UploadCoverToCloudinaryAsync(bedethequeResult.CoverUrl, isbn, cancellationToken);
+        }
+
+        var authors = string.Join(", ", bedethequeResult.Authors);
+        var publishers = string.Join(", ", bedethequeResult.Publishers);
+
+        Log.Information("Mapped Bedetheque result: {Serie} T{Volume} - {Title}", bedethequeResult.Serie, bedethequeResult.VolumeNumber, bedethequeResult.Title);
+
+        return new ComicSearchResult(
+            Title: bedethequeResult.Title,
+            Serie: bedethequeResult.Serie,
+            Isbn: isbn,
+            VolumeNumber: bedethequeResult.VolumeNumber,
+            ImageUrl: imageUrl,
+            Authors: authors,
+            Publishers: publishers,
+            PublishDate: bedethequeResult.PublishDate,
+            NumberOfPages: bedethequeResult.NumberOfPages,
+            Found: true
+        );
     }
 
     private async Task<ComicSearchResult> MapBookResultToComicSearchResultAsync(

--- a/Application/Interfaces/IBedethequeService.cs
+++ b/Application/Interfaces/IBedethequeService.cs
@@ -1,6 +1,5 @@
 namespace Application.Interfaces;
 
-// URI parameters/properties should not be strings
 public record BedethequeBookResult(
     string Title,
     string Serie,

--- a/Application/Interfaces/IBedethequeService.cs
+++ b/Application/Interfaces/IBedethequeService.cs
@@ -1,0 +1,19 @@
+namespace Application.Interfaces;
+
+// URI parameters/properties should not be strings
+public record BedethequeBookResult(
+    string Title,
+    string Serie,
+    int VolumeNumber,
+    IReadOnlyList<string> Authors,
+    IReadOnlyList<string> Publishers,
+    DateOnly? PublishDate,
+    int? NumberOfPages,
+    Uri? CoverUrl,
+    bool Found
+);
+
+public interface IBedethequeService
+{
+    Task<BedethequeBookResult> SearchByIsbnAsync(string isbn, CancellationToken ct = default);
+}

--- a/Application/Interfaces/IIsbnBedethequeCacheRepository.cs
+++ b/Application/Interfaces/IIsbnBedethequeCacheRepository.cs
@@ -1,0 +1,9 @@
+namespace Application.Interfaces;
+
+#pragma warning disable CA1054 // URL parameters stored as strings for DB compatibility
+public interface IIsbnBedethequeCacheRepository
+{
+    Task<string?> GetUrlByIsbnAsync(string isbn, CancellationToken ct = default);
+    Task SaveAsync(string isbn, string url, CancellationToken ct = default);
+}
+#pragma warning restore CA1054

--- a/Domain/Books/IsbnBedethequeUrl.cs
+++ b/Domain/Books/IsbnBedethequeUrl.cs
@@ -1,0 +1,26 @@
+using Domain.Primitives;
+
+namespace Domain.Books;
+
+#pragma warning disable CA1054, CA1056 // URL stored as string in database
+
+public sealed class IsbnBedethequeUrl : Entity<Guid>
+{
+    public string ISBN { get; private set; } = string.Empty;
+
+    public string Url { get; private set; } = string.Empty;
+
+    private IsbnBedethequeUrl() { }
+
+    public static IsbnBedethequeUrl Create(string isbn, string url)
+    {
+        return new IsbnBedethequeUrl
+        {
+            Id = Guid.CreateVersion7(),
+            ISBN = isbn,
+            Url = url,
+            CreatedOnUtc = DateTime.UtcNow
+        };
+    }
+}
+#pragma warning restore CA1054, CA1056

--- a/Persistence/ApplicationDbContext.cs
+++ b/Persistence/ApplicationDbContext.cs
@@ -20,6 +20,8 @@ public class ApplicationDbContext(DbContextOptions options) : DbContext(options)
 
     public DbSet<ReadingDate> ReadingDates => Set<ReadingDate>();
 
+    public DbSet<IsbnBedethequeUrl> IsbnBedethequeUrls => Set<IsbnBedethequeUrl>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -57,6 +59,11 @@ public class ApplicationDbContext(DbContextOptions options) : DbContext(options)
             modelBuilder.Entity<DigitalBook>().ToTable("DigitalBooks");
 
             modelBuilder.Entity<ReadingDate>().ToTable("ReadingDates");
+
+            modelBuilder.Entity<IsbnBedethequeUrl>().ToTable("IsbnBedethequeUrls");
+            modelBuilder.Entity<IsbnBedethequeUrl>().Property(x => x.ISBN).HasMaxLength(20);
+            modelBuilder.Entity<IsbnBedethequeUrl>().Property(x => x.Url).HasMaxLength(500);
+            modelBuilder.Entity<IsbnBedethequeUrl>().HasIndex(x => x.ISBN).IsUnique();
         }
     }
 }

--- a/Persistence/Migrations/20260322203047_AddIsbnBedethequeCacheTable.Designer.cs
+++ b/Persistence/Migrations/20260322203047_AddIsbnBedethequeCacheTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Persistence;
@@ -11,9 +12,11 @@ using Persistence;
 namespace Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260322203047_AddIsbnBedethequeCacheTable")]
+    partial class AddIsbnBedethequeCacheTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Persistence/Migrations/20260322203047_AddIsbnBedethequeCacheTable.cs
+++ b/Persistence/Migrations/20260322203047_AddIsbnBedethequeCacheTable.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistence.Migrations;
+
+/// <inheritdoc />
+public partial class AddIsbnBedethequeCacheTable : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "IsbnBedethequeUrls",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uuid", nullable: false),
+                ISBN = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                Url = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                CreatedOnUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                ModifiedOnUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_IsbnBedethequeUrls", x => x.Id);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_IsbnBedethequeUrls_ISBN",
+            table: "IsbnBedethequeUrls",
+            column: "ISBN",
+            unique: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "IsbnBedethequeUrls");
+    }
+}

--- a/Persistence/ProjectDependencyInjection.cs
+++ b/Persistence/ProjectDependencyInjection.cs
@@ -43,6 +43,8 @@ public static class ProjectDependencyInjection
 
         services.AddScoped<ILibraryLocalStorage>(provider => new LibraryLocalStorage(rootPath));
 
+        services.AddScoped<IIsbnBedethequeCacheRepository, IsbnBedethequeCacheRepository>();
+
         // Config Cloudinary service for cover image storage
         var cloudinarySection = configuration.GetSection("Cloudinary");
         services.AddOptions<CloudinarySettings>()

--- a/Persistence/Repositories/IsbnBedethequeCacheRepository.cs
+++ b/Persistence/Repositories/IsbnBedethequeCacheRepository.cs
@@ -1,0 +1,23 @@
+using Application.Interfaces;
+using Domain.Books;
+using Microsoft.EntityFrameworkCore;
+
+namespace Persistence.Repositories;
+
+public class IsbnBedethequeCacheRepository(ApplicationDbContext dbContext) : IIsbnBedethequeCacheRepository
+{
+    public async Task<string?> GetUrlByIsbnAsync(string isbn, CancellationToken ct = default)
+    {
+        return await dbContext.IsbnBedethequeUrls
+            .Where(x => x.ISBN == isbn)
+            .Select(x => x.Url)
+            .FirstOrDefaultAsync(ct);
+    }
+
+    public async Task SaveAsync(string isbn, string url, CancellationToken ct = default)
+    {
+        var entity = IsbnBedethequeUrl.Create(isbn, url);
+        dbContext.IsbnBedethequeUrls.Add(entity);
+        await dbContext.SaveChangesAsync(ct);
+    }
+}

--- a/Persistence/Repositories/IsbnBedethequeCacheRepository.cs
+++ b/Persistence/Repositories/IsbnBedethequeCacheRepository.cs
@@ -1,6 +1,7 @@
 using Application.Interfaces;
 using Domain.Books;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 
 namespace Persistence.Repositories;
 
@@ -18,6 +19,14 @@ public class IsbnBedethequeCacheRepository(ApplicationDbContext dbContext) : IIs
     {
         var entity = IsbnBedethequeUrl.Create(isbn, url);
         dbContext.IsbnBedethequeUrls.Add(entity);
-        await dbContext.SaveChangesAsync(ct);
+        try
+        {
+            await dbContext.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: "23505" })
+        {
+            // Another concurrent request already cached this ISBN → ignore
+            dbContext.Entry(entity).State = EntityState.Detached;
+        }
     }
 }

--- a/Web/Components/Pages/Books/ImportBookMetaFromWeb.razor
+++ b/Web/Components/Pages/Books/ImportBookMetaFromWeb.razor
@@ -47,6 +47,7 @@
                     <div class="import-field-label">TITLE</div>
                     <MudRadioGroup T="BookSource" @bind-Value="_selectedTitle" Class="import-radio-group">
                         @SourceOption(BookSource.Current,     "CURRENT",      _currentBook.Title)
+                        @SourceOption(BookSource.Bedetheque,  "BEDETHEQUE",   GetBedethequeValue(BookFieldKeys.Title))
                         @SourceOption(BookSource.OpenLibrary, "OPENLIBRARY",  GetOlValue(BookFieldKeys.Title))
                         @SourceOption(BookSource.Google,      "GOOGLE BOOKS", GetGoogleValue(BookFieldKeys.Title))
                     </MudRadioGroup>
@@ -57,6 +58,7 @@
                     <div class="import-field-label">SERIE</div>
                     <MudRadioGroup T="BookSource" @bind-Value="_selectedSerie" Class="import-radio-group">
                         @SourceOption(BookSource.Current,     "CURRENT",      NullIfEmpty(_currentBook.Serie))
+                        @SourceOption(BookSource.Bedetheque,  "BEDETHEQUE",   GetBedethequeValue(BookFieldKeys.Serie))
                         @SourceOption(BookSource.OpenLibrary, "OPENLIBRARY",  GetOlValue(BookFieldKeys.Serie))
                         @SourceOption(BookSource.Google,      "GOOGLE BOOKS", GetGoogleValue(BookFieldKeys.Serie))
                     </MudRadioGroup>
@@ -67,6 +69,7 @@
                     <div class="import-field-label">VOLUME NUMBER</div>
                     <MudRadioGroup T="BookSource" @bind-Value="_selectedVolumeNumber" Class="import-radio-group">
                         @SourceOption(BookSource.Current,     "CURRENT",      _currentBook.VolumeNumber.ToString())
+                        @SourceOption(BookSource.Bedetheque,  "BEDETHEQUE",   GetBedethequeValue(BookFieldKeys.VolumeNumber))
                         @SourceOption(BookSource.OpenLibrary, "OPENLIBRARY",  GetOlValue(BookFieldKeys.VolumeNumber))
                         @SourceOption(BookSource.Google,      "GOOGLE BOOKS", GetGoogleValue(BookFieldKeys.VolumeNumber))
                     </MudRadioGroup>
@@ -77,6 +80,7 @@
                     <div class="import-field-label">AUTHORS</div>
                     <MudRadioGroup T="BookSource" @bind-Value="_selectedAuthors" Class="import-radio-group">
                         @SourceOption(BookSource.Current,     "CURRENT",      NullIfEmpty(_currentBook.Authors))
+                        @SourceOption(BookSource.Bedetheque,  "BEDETHEQUE",   GetBedethequeValue(BookFieldKeys.Authors))
                         @SourceOption(BookSource.OpenLibrary, "OPENLIBRARY",  GetOlValue(BookFieldKeys.Authors))
                         @SourceOption(BookSource.Google,      "GOOGLE BOOKS", GetGoogleValue(BookFieldKeys.Authors))
                     </MudRadioGroup>
@@ -87,6 +91,7 @@
                     <div class="import-field-label">PUBLISHERS</div>
                     <MudRadioGroup T="BookSource" @bind-Value="_selectedPublishers" Class="import-radio-group">
                         @SourceOption(BookSource.Current,     "CURRENT",      NullIfEmpty(_currentBook.Publishers))
+                        @SourceOption(BookSource.Bedetheque,  "BEDETHEQUE",   GetBedethequeValue(BookFieldKeys.Publishers))
                         @SourceOption(BookSource.OpenLibrary, "OPENLIBRARY",  GetOlValue(BookFieldKeys.Publishers))
                         @SourceOption(BookSource.Google,      "GOOGLE BOOKS", GetGoogleValue(BookFieldKeys.Publishers))
                     </MudRadioGroup>
@@ -97,6 +102,7 @@
                     <div class="import-field-label">PUBLISH DATE</div>
                     <MudRadioGroup T="BookSource" @bind-Value="_selectedPublishDate" Class="import-radio-group">
                         @SourceOption(BookSource.Current,     "CURRENT",      _currentBook.PublishDate?.ToString(PublishDateHelper.DisplayFormat))
+                        @SourceOption(BookSource.Bedetheque,  "BEDETHEQUE",   GetBedethequeValue(BookFieldKeys.PublishDate))
                         @SourceOption(BookSource.OpenLibrary, "OPENLIBRARY",  GetOlValue(BookFieldKeys.PublishDate))
                         @SourceOption(BookSource.Google,      "GOOGLE BOOKS", GetGoogleValue(BookFieldKeys.PublishDate))
                     </MudRadioGroup>
@@ -107,6 +113,7 @@
                     <div class="import-field-label">NUMBER OF PAGES</div>
                     <MudRadioGroup T="BookSource" @bind-Value="_selectedNumberOfPages" Class="import-radio-group">
                         @SourceOption(BookSource.Current,     "CURRENT",      _currentBook.NumberOfPages?.ToString())
+                        @SourceOption(BookSource.Bedetheque,  "BEDETHEQUE",   GetBedethequeValue(BookFieldKeys.NumberOfPages))
                         @SourceOption(BookSource.OpenLibrary, "OPENLIBRARY",  GetOlValue(BookFieldKeys.NumberOfPages))
                         @SourceOption(BookSource.Google,      "GOOGLE BOOKS", GetGoogleValue(BookFieldKeys.NumberOfPages))
                     </MudRadioGroup>
@@ -122,6 +129,19 @@
                                 @if (!string.IsNullOrEmpty(_currentBook.ImageLink))
                                 {
                                     <img src="@_currentBook.ImageLink" class="import-cover-thumb" alt="current cover" />
+                                }
+                                else
+                                {
+                                    <span class="import-source-value">—</span>
+                                }
+                            </div>
+                        </MudRadio>
+                        <MudRadio T="BookSource" Value="BookSource.Bedetheque" Dense="true" Disabled="@(_bedethequeResult?.CoverUrl is null)">
+                            <div class="import-option">
+                                <span class="import-source-label">BEDETHEQUE</span>
+                                @if (_bedethequeResult?.CoverUrl is not null)
+                                {
+                                    <img src="@_bedethequeResult.CoverUrl" class="import-cover-thumb" alt="bedetheque cover" />
                                 }
                                 else
                                 {

--- a/Web/Components/Pages/Books/ImportBookMetaFromWeb.razor.cs
+++ b/Web/Components/Pages/Books/ImportBookMetaFromWeb.razor.cs
@@ -124,6 +124,10 @@ public partial class ImportBookMetaFromWeb
             Log.Error(ex, "Error fetching OpenLibrary for ISBN {ISBN}", _currentBook.ISBN);
             Snackbar.Add("Could not fetch data from OpenLibrary. You can still save with current values.", Severity.Warning);
         }
+        finally
+        {
+            StateHasChanged();
+        }
 
         try
         {
@@ -139,20 +143,32 @@ public partial class ImportBookMetaFromWeb
             Log.Error(ex, "Error fetching Google Books for ISBN {ISBN}", _currentBook.ISBN);
             Snackbar.Add("Could not fetch data from Google Books. You can still save with current values.", Severity.Warning);
         }
+        finally
+        {
+            StateHasChanged();
+        }
     }
 
-    private string? GetBedethequeValue(string field) => field switch
+    private string? GetBedethequeValue(string field)
     {
-        BookFieldKeys.Title => _bedethequeResult?.Found == true ? NullIfEmpty(_bedethequeResult.Title) : null,
-        BookFieldKeys.Serie => _bedethequeResult?.Found == true ? NullIfEmpty(_bedethequeResult.Serie) : null,
-        BookFieldKeys.VolumeNumber => _bedethequeResult?.Found == true ? _bedethequeResult.VolumeNumber.ToString(CultureInfo.InvariantCulture) : null,
-        BookFieldKeys.Authors => _bedethequeResult?.Found == true ? NullIfEmpty(string.Join(", ", _bedethequeResult.Authors)) : null,
-        BookFieldKeys.Publishers => _bedethequeResult?.Found == true ? NullIfEmpty(string.Join(", ", _bedethequeResult.Publishers)) : null,
-        BookFieldKeys.PublishDate => _bedethequeResult?.Found == true ? _bedethequeResult.PublishDate?.ToString(PublishDateHelper.DisplayFormat, CultureInfo.InvariantCulture) : null,
-        BookFieldKeys.NumberOfPages => _bedethequeResult?.Found == true ? _bedethequeResult.NumberOfPages?.ToString(CultureInfo.InvariantCulture) : null,
-        BookFieldKeys.Cover => _bedethequeResult?.Found == true ? _bedethequeResult.CoverUrl?.ToString() : null,
-        _ => null
-    };
+        if (_bedethequeResult is not { Found: true } r)
+        {
+            return null;
+        }
+
+        return field switch
+        {
+            BookFieldKeys.Title => NullIfEmpty(r.Title),
+            BookFieldKeys.Serie => NullIfEmpty(r.Serie),
+            BookFieldKeys.VolumeNumber => r.VolumeNumber.ToString(CultureInfo.InvariantCulture),
+            BookFieldKeys.Authors => NullIfEmpty(string.Join(", ", r.Authors)),
+            BookFieldKeys.Publishers => NullIfEmpty(string.Join(", ", r.Publishers)),
+            BookFieldKeys.PublishDate => r.PublishDate?.ToString(PublishDateHelper.DisplayFormat, CultureInfo.InvariantCulture),
+            BookFieldKeys.NumberOfPages => r.NumberOfPages?.ToString(CultureInfo.InvariantCulture),
+            BookFieldKeys.Cover => r.CoverUrl?.ToString(),
+            _ => null
+        };
+    }
 
     private string? GetOlValue(string field) => field switch
     {

--- a/Web/Components/Pages/Books/ImportBookMetaFromWeb.razor.cs
+++ b/Web/Components/Pages/Books/ImportBookMetaFromWeb.razor.cs
@@ -13,6 +13,7 @@ public partial class ImportBookMetaFromWeb
 {
     [Inject] private NavigationManager NavigationManager { get; set; } = default!;
     [Inject] private IBooksService BooksService { get; set; } = default!;
+    [Inject] private IBedethequeService BedethequeService { get; set; } = default!;
     [Inject] private IOpenLibraryService OpenLibraryService { get; set; } = default!;
     [Inject] private IGoogleBooksService GoogleBooksService { get; set; } = default!;
     [Inject] private IComicSearchService ComicSearchService { get; set; } = default!;
@@ -22,6 +23,7 @@ public partial class ImportBookMetaFromWeb
     public string BookId { get; set; } = string.Empty;
 
     private BookUiDto? _currentBook;
+    private BedethequeBookResult? _bedethequeResult;
     private OpenLibraryBookResult? _olResult;
     private GoogleBooksBookResult? _googleResult;
     private ParsedTitleInfo? _olParsed;
@@ -91,10 +93,22 @@ public partial class ImportBookMetaFromWeb
             return;
         }
 
-        // Start both requests concurrently, then await each independently so that
+        // Start all requests concurrently, then await each independently so that
         // a failure in one provider does not prevent the other's result from being used.
+        var bedethequeTask = BedethequeService.SearchByIsbnAsync(_currentBook.ISBN);
         var olTask = OpenLibraryService.SearchByIsbnAsync(_currentBook.ISBN);
         var googleTask = GoogleBooksService.SearchByIsbnAsync(_currentBook.ISBN);
+
+        try
+        {
+            _bedethequeResult = await bedethequeTask;
+            StateHasChanged();
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+        {
+            Log.Error(ex, "Error fetching Bedetheque for ISBN {ISBN}", _currentBook.ISBN);
+            Snackbar.Add("Could not fetch data from Bedetheque. You can still save with current values.", Severity.Warning);
+        }
 
         try
         {
@@ -126,6 +140,19 @@ public partial class ImportBookMetaFromWeb
             Snackbar.Add("Could not fetch data from Google Books. You can still save with current values.", Severity.Warning);
         }
     }
+
+    private string? GetBedethequeValue(string field) => field switch
+    {
+        BookFieldKeys.Title => _bedethequeResult?.Found == true ? NullIfEmpty(_bedethequeResult.Title) : null,
+        BookFieldKeys.Serie => _bedethequeResult?.Found == true ? NullIfEmpty(_bedethequeResult.Serie) : null,
+        BookFieldKeys.VolumeNumber => _bedethequeResult?.Found == true ? _bedethequeResult.VolumeNumber.ToString(CultureInfo.InvariantCulture) : null,
+        BookFieldKeys.Authors => _bedethequeResult?.Found == true ? NullIfEmpty(string.Join(", ", _bedethequeResult.Authors)) : null,
+        BookFieldKeys.Publishers => _bedethequeResult?.Found == true ? NullIfEmpty(string.Join(", ", _bedethequeResult.Publishers)) : null,
+        BookFieldKeys.PublishDate => _bedethequeResult?.Found == true ? _bedethequeResult.PublishDate?.ToString(PublishDateHelper.DisplayFormat, CultureInfo.InvariantCulture) : null,
+        BookFieldKeys.NumberOfPages => _bedethequeResult?.Found == true ? _bedethequeResult.NumberOfPages?.ToString(CultureInfo.InvariantCulture) : null,
+        BookFieldKeys.Cover => _bedethequeResult?.Found == true ? _bedethequeResult.CoverUrl?.ToString() : null,
+        _ => null
+    };
 
     private string? GetOlValue(string field) => field switch
     {
@@ -170,6 +197,7 @@ public partial class ImportBookMetaFromWeb
 
         return source switch
         {
+            BookSource.Bedetheque => GetBedethequeValue(field),
             BookSource.OpenLibrary => GetOlValue(field),
             BookSource.Google => GetGoogleValue(field),
             _ => GetCurrentValue(field)
@@ -260,6 +288,7 @@ public partial class ImportBookMetaFromWeb
 public enum BookSource
 {
     Current,
+    Bedetheque,
     OpenLibrary,
     Google
 }

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -66,6 +66,23 @@ builder.Services.AddHttpClient<IGoogleBooksService, GoogleBooksService>(client =
     client.Timeout = TimeSpan.FromSeconds(30);
 });
 
+// Config Bedetheque settings
+var bedethequeSection = configuration.GetSection("Bedetheque");
+builder.Services.AddOptions<BedethequeSettings>()
+    .Bind(bedethequeSection)
+    .ValidateOnStart();
+
+// Config Bedetheque HTTP clients
+builder.Services.AddHttpClient("Bedetheque", client =>
+{
+    client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+    client.Timeout = TimeSpan.FromSeconds(30);
+});
+builder.Services.AddHttpClient("SerpApi", client => client.Timeout = TimeSpan.FromSeconds(15));
+
+// Config Bedetheque service
+builder.Services.AddScoped<IBedethequeService, BedethequeService>();
+
 builder.Services
     .AddApplication()
     .AddInfrastructure(connectionString, configuration["LocalStorage:RootPath"]!, configuration);

--- a/Web/appsettings.json
+++ b/Web/appsettings.json
@@ -49,7 +49,7 @@
   "Bedetheque": {
     "BaseUrl": "https://www.bedetheque.com",
     "SerpApiBaseUrl": "https://serpapi.com",
-    "SerpApiKey": "serpapikey"
+    "SerpApiKey": ""
   }
 }
 

--- a/Web/appsettings.json
+++ b/Web/appsettings.json
@@ -45,6 +45,11 @@
   },
   "GoogleBooks": {
     "BaseUrl": "https://www.googleapis.com/books/v1"
+  },
+  "Bedetheque": {
+    "BaseUrl": "https://www.bedetheque.com",
+    "SerpApiBaseUrl": "https://serpapi.com",
+    "SerpApiKey": "serpapikey"
   }
 }
 

--- a/tests/Application.UnitTests/ComicInfoSearch/BedethequeServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/BedethequeServiceTests.cs
@@ -158,7 +158,12 @@ public sealed class BedethequeServiceTests : IDisposable
     [Fact]
     public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenSerpApiKeyIsEmpty()
     {
-        var settings = new BedethequeSettings { SerpApiKey = "" };
+        var settings = new BedethequeSettings 
+        { 
+            SerpApiKey = "",
+            BaseUrl = new Uri("https://www.bedetheque.com"),
+            SerpApiBaseUrl = new Uri("https://serpapi.com")
+        };      
         var service = CreateService(Substitute.For<IHttpClientFactory>(), settings: settings);
 
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -169,7 +174,12 @@ public sealed class BedethequeServiceTests : IDisposable
     [Fact]
     public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenSerpApiKeyIsWhitespace()
     {
-        var settings = new BedethequeSettings { SerpApiKey = "   " };
+        var settings = new BedethequeSettings 
+        { 
+            SerpApiKey = "   ",
+            BaseUrl = new Uri("https://www.bedetheque.com"),
+            SerpApiBaseUrl = new Uri("https://serpapi.com")
+        };
         var service = CreateService(Substitute.For<IHttpClientFactory>(), settings: settings);
 
         var result = await service.SearchByIsbnAsync(ValidIsbn);
@@ -383,6 +393,40 @@ public sealed class BedethequeServiceTests : IDisposable
         var result = await CreateService(PageFactory(html), cache).SearchByIsbnAsync(ValidIsbn);
 
         result.Authors.Should().ContainSingle().Which.Should().Be("Silas, Stan");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ParseMultipleAuthors_WhenMultipleAnchorsUnderScenarioLabel()
+    {
+        var html = """
+            <html><body><ul class="infos-albums">
+              <li><label>Titre : </label>Album</li>
+              <li><label>Scénario :</label><a href="/auteur-1">Alpha, Jean</a><a href="/auteur-2">Beta, Marie</a></li>
+            </ul></body></html>
+            """;
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(html), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.Authors.Should().HaveCount(2);
+        result.Authors.Should().Contain("Alpha, Jean");
+        result.Authors.Should().Contain("Beta, Marie");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ParseMultipleAuthors_WhenMultipleAnchorsUnderDessinLabel()
+    {
+        var html = """
+            <html><body><ul class="infos-albums">
+              <li><label>Titre : </label>Album</li>
+              <li><label>Dessin :</label><a href="/auteur-1">Alpha, Jean</a><a href="/auteur-2">Beta, Marie</a></li>
+            </ul></body></html>
+            """;
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(html), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.Authors.Should().HaveCount(2);
+        result.Authors.Should().Contain("Alpha, Jean");
+        result.Authors.Should().Contain("Beta, Marie");
     }
 
     [Fact]

--- a/tests/Application.UnitTests/ComicInfoSearch/BedethequeServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/BedethequeServiceTests.cs
@@ -149,8 +149,9 @@ public sealed class BedethequeServiceTests : IDisposable
         var factory = PageFactory();
         var service = CreateService(factory, cache);
 
-        await service.SearchByIsbnAsync(ValidIsbn);
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
 
+        Assert.NotNull(result);
         factory.DidNotReceive().CreateClient("SerpApi");
     }
 

--- a/tests/Application.UnitTests/ComicInfoSearch/BedethequeServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/BedethequeServiceTests.cs
@@ -1,0 +1,544 @@
+using System.Net;
+using Application.ComicInfoSearch;
+using Application.Interfaces;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Application.UnitTests.ComicInfoSearch;
+
+public sealed class BedethequeServiceTests : IDisposable
+{
+    private const string ValidIsbn = "9782205057317";
+    private const string ValidIsbnWithDashes = "978-2-205-05731-7";
+    private const string PageUrl = "https://www.bedetheque.com/BD-Biguden-Tome-1-LAnkou-224335.html";
+    private const string ExpectedCoverUrl = "https://www.bedetheque.com/media/Couvertures/Couv_224335.jpg";
+
+    private static readonly BedethequeSettings DefaultSettings = new()
+    {
+        SerpApiKey = "test-key",
+        SerpApiBaseUrl = new Uri("https://serpapi.com"),
+        BaseUrl = new Uri("https://www.bedetheque.com")
+    };
+
+    // Minimal full-featured HTML matching the real Bedetheque infos-albums structure
+    private const string FullAlbumHtml = """
+        <html><body>
+        <ul class="infos-albums">
+          <li><label>Série : </label>Biguden</li>
+          <li><label>Titre : </label>L'Ankou</li>
+          <li><label>Tome : </label>1</li>
+          <li><label>Scénario :</label><a href="/auteur-1">Silas, Stan</a></li>
+          <li><label>Dessin :</label><a href="/auteur-2">Dupont, Jean</a></li>
+          <li><label>Dépot légal : </label>08/2014<span class="grise"> (Parution le 27/08/2014)</span></li>
+          <li><label>Editeur : </label><span>EP Media</span></li>
+          <li><label>Planches :</label><span>62</span></li>
+        </ul>
+        </body></html>
+        """;
+
+    // ── Disposal tracker ─────────────────────────────────────────────
+
+    private readonly List<IDisposable> _disposables = [];
+
+    public void Dispose()
+    {
+        foreach (var d in _disposables)
+        {
+            d.Dispose();
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private T Track<T>(T disposable) where T : IDisposable
+    {
+        _disposables.Add(disposable);
+        return disposable;
+    }
+
+    // ── Factories / helpers ───────────────────────────────────────────
+
+    private static BedethequeService CreateService(
+        IHttpClientFactory factory,
+        IIsbnBedethequeCacheRepository? cache = null,
+        BedethequeSettings? settings = null)
+    {
+        cache ??= EmptyCache();
+        var options = Options.Create(settings ?? DefaultSettings);
+        return new BedethequeService(factory, cache, options);
+    }
+
+    private static IIsbnBedethequeCacheRepository EmptyCache()
+    {
+        var cache = Substitute.For<IIsbnBedethequeCacheRepository>();
+        cache.GetUrlByIsbnAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+             .Returns((string?)null);
+        return cache;
+    }
+
+    private static IIsbnBedethequeCacheRepository CacheWithUrl(string isbn, string url)
+    {
+        var cache = Substitute.For<IIsbnBedethequeCacheRepository>();
+        cache.GetUrlByIsbnAsync(isbn, Arg.Any<CancellationToken>()).Returns(url);
+        return cache;
+    }
+
+    private IHttpClientFactory FactoryWith(
+        HttpMessageHandler? serpHandler = null,
+        HttpMessageHandler? bedeHandler = null)
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        if (serpHandler != null)
+        {
+            factory.CreateClient("SerpApi").Returns(Track(new HttpClient(serpHandler)));
+        }
+        if (bedeHandler != null)
+        {
+            factory.CreateClient("Bedetheque").Returns(Track(new HttpClient(bedeHandler)));
+        }
+        return factory;
+    }
+
+    // Factory that serves a page directly (used with CacheWithUrl)
+    private IHttpClientFactory PageFactory(string html = FullAlbumHtml) =>
+        FactoryWith(bedeHandler: Track(new FakeHttpMessageHandler(_ => HtmlResponse(html))));
+
+    // Factory with both SerpApi + Bedetheque page handlers
+    private IHttpClientFactory SerpAndPageFactory(string serpJson, string html = FullAlbumHtml) =>
+        FactoryWith(
+            Track(new FakeHttpMessageHandler(_ => JsonResponse(serpJson))),
+            Track(new FakeHttpMessageHandler(_ => HtmlResponse(html))));
+
+    private static HttpResponseMessage JsonResponse(string json) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+        };
+
+    private static HttpResponseMessage HtmlResponse(string html) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(html, System.Text.Encoding.UTF8, "text/html")
+        };
+
+    private static string SerpApiJson(params string[] links)
+    {
+        var items = string.Join(",", links.Select(l => $$"""{"link":"{{l}}"}"""));
+        return $$"""{"organic_results":[{{items}}]}""";
+    }
+
+    // ── SearchByIsbnAsync — URL resolution ───────────────────────────
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnResult_WhenCacheHit()
+    {
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var service = CreateService(PageFactory(), cache);
+
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        result.Found.Should().BeTrue();
+        result.Title.Should().Be("L'Ankou");
+        result.Serie.Should().Be("Biguden");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_NotCallSerpApi_WhenCacheHit()
+    {
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var factory = PageFactory();
+        var service = CreateService(factory, cache);
+
+        await service.SearchByIsbnAsync(ValidIsbn);
+
+        factory.DidNotReceive().CreateClient("SerpApi");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenSerpApiKeyIsEmpty()
+    {
+        var settings = new BedethequeSettings { SerpApiKey = "" };
+        var service = CreateService(Substitute.For<IHttpClientFactory>(), settings: settings);
+
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        result.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenSerpApiKeyIsWhitespace()
+    {
+        var settings = new BedethequeSettings { SerpApiKey = "   " };
+        var service = CreateService(Substitute.For<IHttpClientFactory>(), settings: settings);
+
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        result.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenSerpApiReturnsNonSuccess()
+    {
+        var factory = FactoryWith(Track(new FakeHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized))));
+        var service = CreateService(factory);
+
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        result.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenNoBdLinksInSerpApiResponse()
+    {
+        var serpJson = SerpApiJson("https://www.amazon.com/book", "https://www.fnac.com/book");
+        var service = CreateService(FactoryWith(Track(new FakeHttpMessageHandler(_ => JsonResponse(serpJson)))));
+
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        result.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenMultipleBdLinksInSerpApiResponse()
+    {
+        var serpJson = SerpApiJson(
+            "https://www.bedetheque.com/BD-Series-Tome-1-Title-111.html",
+            "https://www.bedetheque.com/BD-Series-Tome-2-Title-222.html");
+        var service = CreateService(FactoryWith(Track(new FakeHttpMessageHandler(_ => JsonResponse(serpJson)))));
+
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        result.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenSerpApiHasNullOrganicResults()
+    {
+        var factory = FactoryWith(Track(new FakeHttpMessageHandler(_ => JsonResponse("""{"organic_results":null}"""))));
+        var service = CreateService(factory);
+
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        result.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_SaveUrlToCache_WhenExactlyOneBdLinkFound()
+    {
+        var cache = EmptyCache();
+        var service = CreateService(SerpAndPageFactory(SerpApiJson(PageUrl)), cache);
+
+        await service.SearchByIsbnAsync(ValidIsbn);
+
+        await cache.Received(1).SaveAsync(ValidIsbn, PageUrl, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenPageFetchFails()
+    {
+        var factory = FactoryWith(
+            Track(new FakeHttpMessageHandler(_ => JsonResponse(SerpApiJson(PageUrl)))),
+            Track(new FakeHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound))));
+        var service = CreateService(factory);
+
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        result.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_NormalizeIsbn_WhenIsbnContainsDashes()
+    {
+        // Cache is keyed on the cleaned ISBN (no dashes)
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var service = CreateService(PageFactory(), cache);
+
+        var result = await service.SearchByIsbnAsync(ValidIsbnWithDashes);
+
+        result.Found.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenHttpRequestFails()
+    {
+        var factory = FactoryWith(Track(new FakeHttpMessageHandler(new HttpRequestException("Network error"))));
+        var service = CreateService(factory);
+
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        result.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenJsonParsingFails()
+    {
+        var factory = FactoryWith(Track(new FakeHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("invalid json {{{", System.Text.Encoding.UTF8, "application/json")
+        })));
+        var service = CreateService(factory);
+
+        var result = await service.SearchByIsbnAsync(ValidIsbn);
+
+        result.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNotFound_WhenTimeoutOccurs()
+    {
+        // TaskCanceledException without a cancelled caller token → internal timeout
+        var factory = FactoryWith(Track(new FakeHttpMessageHandler(new TaskCanceledException("Timeout"))));
+        var service = CreateService(factory);
+
+        var result = await service.SearchByIsbnAsync(ValidIsbn, CancellationToken.None);
+
+        result.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_PropagateCancellation_WhenCallerCancels()
+    {
+        using var cts = new CancellationTokenSource();
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var factory = PageFactory();
+        var service = CreateService(factory, cache);
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<TaskCanceledException>(
+            () => service.SearchByIsbnAsync(ValidIsbn, cts.Token));
+    }
+
+    // ── SearchByIsbnAsync — HTML parsing ─────────────────────────────
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ParseTitle_WhenTitreFieldPresent()
+    {
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.Title.Should().Be("L'Ankou");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnEmptyTitle_WhenTitreFieldMissing()
+    {
+        var html = """<html><body><ul class="infos-albums"><li><label>Série : </label>OnlySerie</li></ul></body></html>""";
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(html), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.Title.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ParseSerie_WhenSerieFieldPresent()
+    {
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.Serie.Should().Be("Biguden");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ParseVolumeNumber_WhenTomeFieldPresent()
+    {
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.VolumeNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_DefaultVolumeNumberToOne_WhenTomeFieldMissing()
+    {
+        var html = """<html><body><ul class="infos-albums"><li><label>Titre : </label>Album</li></ul></body></html>""";
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(html), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.VolumeNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ParseBothAuthors_WhenScenarioAndDessinAreDifferent()
+    {
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.Authors.Should().HaveCount(2);
+        result.Authors.Should().Contain("Silas, Stan");
+        result.Authors.Should().Contain("Dupont, Jean");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_DeduplicateAuthors_WhenScenarioAndDessinAreSamePerson()
+    {
+        var html = """
+            <html><body><ul class="infos-albums">
+              <li><label>Titre : </label>Album</li>
+              <li><label>Scénario :</label><a href="/auteur-1">Silas, Stan</a></li>
+              <li><label>Dessin :</label><a href="/auteur-1">Silas, Stan</a></li>
+            </ul></body></html>
+            """;
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(html), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.Authors.Should().ContainSingle().Which.Should().Be("Silas, Stan");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnEmptyAuthors_WhenNoAuthorFields()
+    {
+        var html = """<html><body><ul class="infos-albums"><li><label>Titre : </label>Album</li></ul></body></html>""";
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(html), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.Authors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ParsePublisher_WhenEditeurFieldPresent()
+    {
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.Publishers.Should().ContainSingle().Which.Should().Be("EP Media");
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnEmptyPublishers_WhenNoEditeurField()
+    {
+        var html = """<html><body><ul class="infos-albums"><li><label>Titre : </label>Album</li></ul></body></html>""";
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(html), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.Publishers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ParsePublishDate_FromParutionLeDate()
+    {
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.PublishDate.Should().Be(new DateOnly(2014, 8, 27));
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ParsePublishDate_FromMonthYearFallback()
+    {
+        var html = """
+            <html><body><ul class="infos-albums">
+              <li><label>Titre : </label>Album</li>
+              <li><label>Dépot légal : </label>11/2025</li>
+            </ul></body></html>
+            """;
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(html), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.PublishDate.Should().Be(new DateOnly(2025, 11, 1));
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNullPublishDate_WhenNoDateField()
+    {
+        var html = """<html><body><ul class="infos-albums"><li><label>Titre : </label>Album</li></ul></body></html>""";
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(html), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.PublishDate.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ParseNumberOfPages_WhenPlanchesFieldPresent()
+    {
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.NumberOfPages.Should().Be(62);
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNullNumberOfPages_WhenPlanchesMissing()
+    {
+        var html = """<html><body><ul class="infos-albums"><li><label>Titre : </label>Album</li></ul></body></html>""";
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(html), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.NumberOfPages.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_BuildCoverUrl_WhenPageUrlContainsNumericId()
+    {
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.CoverUrl.Should().Be(new Uri(ExpectedCoverUrl));
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnNullCoverUrl_WhenPageUrlHasNoNumericId()
+    {
+        var noIdUrl = "https://www.bedetheque.com/BD-Biguden-LAnkou.html";
+        var cache = CacheWithUrl(ValidIsbn, noIdUrl);
+        var result = await CreateService(PageFactory(), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.CoverUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnFoundTrue_WhenTitlePresent()
+    {
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.Found.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnFoundTrue_WhenOnlySeriePresent()
+    {
+        var html = """<html><body><ul class="infos-albums"><li><label>Série : </label>OnlySerie</li></ul></body></html>""";
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(html), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.Found.Should().BeTrue();
+        result.Serie.Should().Be("OnlySerie");
+        result.Title.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_Should_ReturnFoundFalse_WhenBothTitleAndSerieEmpty()
+    {
+        var html = """<html><body><ul class="infos-albums"></ul></body></html>""";
+        var cache = CacheWithUrl(ValidIsbn, PageUrl);
+        var result = await CreateService(PageFactory(html), cache).SearchByIsbnAsync(ValidIsbn);
+
+        result.Found.Should().BeFalse();
+    }
+
+    // ── Handler ──────────────────────────────────────────────────────
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage>? _factory;
+        private readonly Exception? _exception;
+
+        public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> factory)
+            => _factory = factory;
+
+        public FakeHttpMessageHandler(Exception exception)
+            => _exception = exception;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (_exception is not null)
+            {
+                throw _exception;
+            }
+
+            return Task.FromResult(_factory!(request));
+        }
+    }
+}

--- a/tests/Application.UnitTests/ComicInfoSearch/ComicSearchServiceTests.cs
+++ b/tests/Application.UnitTests/ComicInfoSearch/ComicSearchServiceTests.cs
@@ -15,14 +15,40 @@ public sealed class ComicSearchServiceTests
 
     private readonly IOpenLibraryService _openLibraryService;
     private readonly IGoogleBooksService _googleBooksService;
+    private readonly IBedethequeService _bedethequeService;
     private readonly ICloudinaryService _cloudinaryService;
     private readonly IOptions<CloudinarySettings> _cloudinarySettings;
     private readonly ComicSearchService _sut;
+
+    private static BedethequeBookResult BedethequeNotFound => new(
+        Title: string.Empty,
+        Serie: string.Empty,
+        VolumeNumber: 1,
+        Authors: [],
+        Publishers: [],
+        PublishDate: null,
+        NumberOfPages: null,
+        CoverUrl: null,
+        Found: false);
+
+    private static GoogleBooksBookResult GoogleBooksNotFound => new(
+        Title: string.Empty,
+        Subtitle: null,
+        Authors: [],
+        Publishers: [],
+        PublishDate: null,
+        NumberOfPages: null,
+        CoverUrl: null,
+        Description: null,
+        Categories: [],
+        Language: null,
+        Found: false);
 
     public ComicSearchServiceTests()
     {
         _openLibraryService = Substitute.For<IOpenLibraryService>();
         _googleBooksService = Substitute.For<IGoogleBooksService>();
+        _bedethequeService = Substitute.For<IBedethequeService>();
         _cloudinaryService = Substitute.For<ICloudinaryService>();
         _cloudinarySettings = Options.Create(new CloudinarySettings
         {
@@ -31,7 +57,14 @@ public sealed class ComicSearchServiceTests
             ApiSecret = "test-secret",
             Folder = "test-covers"
         });
-        _sut = new ComicSearchService(_openLibraryService, _googleBooksService, _cloudinaryService, _cloudinarySettings);
+
+        // Default: Bedetheque and Google Books return not found so tests focused on OpenLibrary still work
+        _bedethequeService.SearchByIsbnAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(BedethequeNotFound);
+        _googleBooksService.SearchByIsbnAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(GoogleBooksNotFound);
+
+        _sut = new ComicSearchService(_openLibraryService, _googleBooksService, _bedethequeService, _cloudinaryService, _cloudinarySettings);
     }
 
     #region SearchByIsbnAsync Tests
@@ -917,28 +950,32 @@ public sealed class ComicSearchServiceTests
     }
 
     [Fact]
-    public async Task SearchByIsbnAsync_ShouldNotCallGoogleBooks_WhenOpenLibraryReturnsData()
+    public async Task SearchByIsbnAsync_ShouldNotCallGoogleBooksOrOpenLibrary_WhenBedethequeReturnsData()
     {
         // Arrange
         const string isbn = "9781234567890";
-        var openLibraryResult = new OpenLibraryBookResult(
-            Title: "Test Comic",
-            Subtitle: null,
-            Authors: SingleAuthorArray,
-            Publishers: SinglePublisherArray,
-            PublishDate: null,
-            NumberOfPages: 100,
+        var bedethequeResult = new BedethequeBookResult(
+            Title: "L'Ankou",
+            Serie: "Biguden",
+            VolumeNumber: 1,
+            Authors: ["Stan Silas"],
+            Publishers: ["EP Media"],
+            PublishDate: new DateOnly(2014, 8, 1),
+            NumberOfPages: 62,
             CoverUrl: null,
             Found: true);
 
-        _openLibraryService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
-            .Returns(openLibraryResult);
+        _bedethequeService.SearchByIsbnAsync(isbn, Arg.Any<CancellationToken>())
+            .Returns(bedethequeResult);
 
         // Act
         await _sut.SearchByIsbnAsync(isbn);
 
         // Assert
         await _googleBooksService.DidNotReceive().SearchByIsbnAsync(
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+        await _openLibraryService.DidNotReceive().SearchByIsbnAsync(
             Arg.Any<string>(),
             Arg.Any<CancellationToken>());
     }

--- a/tests/Base.Integration.Tests/BaseIntegrationTest.cs
+++ b/tests/Base.Integration.Tests/BaseIntegrationTest.cs
@@ -132,3 +132,13 @@ public class BookReadServiceIntegrationTest : BookIntegrationTest
     }
 
 }
+
+public class IsbnBedethequeCacheIntegrationTest : BaseIntegrationTest
+{
+    protected IIsbnBedethequeCacheRepository CacheRepository { get; }
+
+    public IsbnBedethequeCacheIntegrationTest(IntegrationTestWebAppFactory factory) : base(factory)
+    {
+        CacheRepository = _scope.ServiceProvider.GetRequiredService<IIsbnBedethequeCacheRepository>();
+    }
+}

--- a/tests/Persistence.Integration.Tests/Integration/Repositories/IsbnBedethequeCacheRepositoryTests.cs
+++ b/tests/Persistence.Integration.Tests/Integration/Repositories/IsbnBedethequeCacheRepositoryTests.cs
@@ -1,0 +1,131 @@
+using Base.Integration.Tests;
+
+namespace Persistence.Tests.Integration.Repositories;
+
+[Collection("DatabaseCollectionTests")]
+public sealed class IsbnBedethequeCacheRepositoryTests(IntegrationTestWebAppFactory factory)
+    : IsbnBedethequeCacheIntegrationTest(factory)
+{
+    private const string TestIsbn = "9782205057317";
+    private const string TestUrl = "https://www.bedetheque.com/BD-Biguden-Tome-1-LAnkou-224335.html";
+
+    [Fact]
+    public async Task GetUrlByIsbnAsync_ShouldReturnNull_WhenIsbnNotCached()
+    {
+        // Act
+        var result = await CacheRepository.GetUrlByIsbnAsync("9780000000000");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SaveAsync_ThenGetUrlByIsbnAsync_ShouldReturnSavedUrl()
+    {
+        // Arrange
+        var isbn = UniqueIsbn();
+        var url = "https://www.bedetheque.com/BD-Test-224335.html";
+
+        // Act
+        await CacheRepository.SaveAsync(isbn, url);
+        var result = await CacheRepository.GetUrlByIsbnAsync(isbn);
+
+        // Assert
+        result.Should().Be(url);
+    }
+
+    [Fact]
+    public async Task GetUrlByIsbnAsync_ShouldReturnNull_WhenDifferentIsbnQueried()
+    {
+        // Arrange
+        var isbn = UniqueIsbn();
+        await CacheRepository.SaveAsync(isbn, TestUrl);
+
+        // Act
+        var result = await CacheRepository.GetUrlByIsbnAsync("9780000000001");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SaveAsync_ShouldNotThrow_WhenSamePairSavedTwice()
+    {
+        // Arrange
+        var isbn = UniqueIsbn();
+
+        // Act
+        await CacheRepository.SaveAsync(isbn, TestUrl);
+        var action = async () => await CacheRepository.SaveAsync(isbn, TestUrl);
+
+        // Assert — duplicate key must be silently ignored
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task GetUrlByIsbnAsync_ShouldReturnFirstUrl_WhenDuplicateSaveAttempted()
+    {
+        // Arrange
+        var isbn = UniqueIsbn();
+        var firstUrl = "https://www.bedetheque.com/BD-First-111111.html";
+        var secondUrl = "https://www.bedetheque.com/BD-Second-222222.html";
+
+        // Act
+        await CacheRepository.SaveAsync(isbn, firstUrl);
+        await CacheRepository.SaveAsync(isbn, secondUrl); // duplicate — should be silently ignored
+
+        var result = await CacheRepository.GetUrlByIsbnAsync(isbn);
+
+        // Assert — first saved URL is preserved
+        result.Should().Be(firstUrl);
+    }
+
+    [Fact]
+    public async Task SaveAsync_ShouldPersistMultipleDistinctIsbns()
+    {
+        // Arrange
+        var isbn1 = UniqueIsbn();
+        var isbn2 = UniqueIsbn();
+        var url1 = "https://www.bedetheque.com/BD-SerieA-100001.html";
+        var url2 = "https://www.bedetheque.com/BD-SerieB-100002.html";
+
+        // Act
+        await CacheRepository.SaveAsync(isbn1, url1);
+        await CacheRepository.SaveAsync(isbn2, url2);
+
+        // Assert
+        (await CacheRepository.GetUrlByIsbnAsync(isbn1)).Should().Be(url1);
+        (await CacheRepository.GetUrlByIsbnAsync(isbn2)).Should().Be(url2);
+    }
+
+    [Fact]
+    public async Task SaveAsync_ShouldRespectCancellationToken()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Act
+        var action = async () => await CacheRepository.SaveAsync(UniqueIsbn(), TestUrl, cts.Token);
+
+        // Assert
+        await action.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task GetUrlByIsbnAsync_ShouldRespectCancellationToken()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Act
+        var action = async () => await CacheRepository.GetUrlByIsbnAsync(TestIsbn, cts.Token);
+
+        // Assert
+        await action.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    // Each test gets its own unique ISBN to stay isolated inside the shared transaction.
+    private static string UniqueIsbn() => $"978{Guid.NewGuid().ToString("N")[..10]}";
+}


### PR DESCRIPTION
Integrates Bedetheque.com as the first source for comic book metadata, using SerpApi and HTML parsing with persistent ISBN-to-URL caching. Updates search and import flows to prefer Bedetheque, with Google Books and OpenLibrary as fallbacks. Enhances the import UI to support Bedetheque for all fields and cover images. Adds new cache table, repository, configuration, and tests for the new provider. All changes are backward compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bedetheque integrated as a new metadata search provider and now preferred when available.
  * Per-field source selection updated to include Bedetheque for title, series, volume, authors, publishers, publish date, pages, and cover (Bedetheque cover shown when available).
  * Bedetheque integration is configurable via app settings and includes resilient lookup with optional caching.

* **Tests**
  * Added unit and integration tests covering Bedetheque lookups, caching behavior, error handling, and UI import flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->